### PR TITLE
Restore migrated homepage, CV, and repositories

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ title: "Zhihao LIU" # used by SEO/meta tags and search engines
 first_name: Zhihao
 middle_name:
 last_name: LIU
+tab_title: "Zhihao LIU | Climate & Energy Data Scientist" # preserves the previous browser-tab title customization
 contact_note: >
   feel free to reach me.
 description: >
@@ -18,6 +19,7 @@ lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
 icon: 📓 # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
 
 url: https://zhihaol.eu.org # the base hostname & protocol for your site
+alternate_site_name: "Zhihao Liu | Geodata | Energy Transition | Bayesian Modeling"
 baseurl: # the subpath of your site, e.g. /blog/. Leave blank for root
 last_updated: false # set to true if you want to display last updated in the footer
 impressum_path: # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR

--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -1,111 +1,150 @@
-- title: Summary
-  type: map
-  contents:
-    - name: Focus
-      value: AI Agent for Energy & Climate
-    - name: Strengths
-      value: Uncertainty-aware modeling, specializing in the digitalization of MRV and 4D seismic monitoring for CCUS cluster governance.
-    - name: Book a chat
-      links:
-        - name: Google Calendar
-          link: https://calendar.app.google/UQ267iEs4MTAGFSd7
+cv:
+  name: Zhihao LIU
+  label: Climate & Energy Data Scientist
+  email: zhihaol[at]uio.com
+  location: Oslo / Bergen, Norway
+  image: ""
+  summary: Climate and energy data scientist building uncertainty-aware, reproducible ML workflows and decision tools from climate, geospatial, and geophysical data.
 
-- title: Experience
-  type: time_table
-  contents:
-    - title: Business Development Manager (New Energy)
-      institution: BGP CNPC
-      year: 2024.07 - Present
-      description:
-        - Client-facing work translating technical constraints into commercial proposals and delivery plans; architecting Digital Carbon Monitoring & MRV frameworks to strengthen a data-to-decision mindset.
+  social_networks:
+    - network: GitHub
+      username: liuh886
+    - network: LinkedIn
+      username: liuzhihao
 
-    - title: Principal
-      institution: LIU GEOCONSULTING
-      year: 2023.12 - 2024.06
-      description:
-        - Built a real-time state-estimation prototype (Unscented Kalman Filter) with FastAPI + PostgreSQL.
-        - Converted modeling output into user-facing service features as a blueprint for scalable B2B decision tools.
-        - Consulting service for Eurostar.
+  sections:
+    Summary:
+      - name: Focus
+        summary: AI Agent for Energy & Climate
+      - name: Strengths
+        summary: Uncertainty-aware modeling, specializing in the digitalization of MRV and 4D seismic monitoring for CCUS cluster governance.
+      - name: Book a chat
+        url: https://calendar.app.google/UQ267iEs4MTAGFSd7
+        summary: Google Calendar
 
-    - title: Research Assistant (Energy & Climate Data Science)
-      institution: University of Oslo
-      year: 2021.11 - 2023.12
-      description:
-        - Bias correction and spatial downscaling workflows for climate/weather data with energy applications in mind.
-        - Remote sensing + ML for seasonal snow; contributed to reproducible research workflows and open-source tooling.
+    Experience:
+      - company: BGP CNPC
+        position: Business Development Manager (New Energy)
+        start_date: 2024-07
+        end_date: present
+        summary: Client-facing work translating technical constraints into commercial proposals and delivery plans; architecting Digital Carbon Monitoring & MRV frameworks to strengthen a data-to-decision mindset.
 
-- title: Skills
-  type: map
-  contents:
-    - name: Programming
-      value: Python, SQL, Git
-    - name: ML & Statistics
-      value: Bayesian inference, Kalman filtering, machine learning, evaluation under uncertainty
-    - name: Data & Engineering
-      value: FastAPI, PostgreSQL, Docker, ETL, REST APIs
-    - name: Geospatial
-      value: Xarray, GeoPandas, Rasterio, Shapely, GIS automation
-    - name: Domains
-      value: CCUS, AI Agent, Climate & energy datasets, remote sensing, geophysical data
+      - company: LIU GEOCONSULTING
+        position: Principal
+        start_date: 2023-12
+        end_date: 2024-06
+        highlights:
+          - Built a real-time state-estimation prototype with Unscented Kalman Filter, FastAPI, and PostgreSQL.
+          - Converted modeling output into user-facing service features as a blueprint for scalable B2B decision tools.
+          - Consulting service for Eurostar.
 
-- title: Education
-  type: time_table
-  contents:
-    - title: M.Sc. Geoscience
-      institution: University of Oslo (Norway)
-      year: 2021 - 2023
-      description:
-        - "Thesis: Snow depth retrieval and downscaling using satellite laser altimetry, machine learning, and climate reanalysis."
-        - "GPA: 3.9/4.0."
+      - company: University of Oslo
+        position: Research Assistant (Energy & Climate Data Science)
+        location: Oslo, Norway
+        start_date: 2021-11
+        end_date: 2023-12
+        highlights:
+          - Bias correction and spatial downscaling workflows for climate/weather data with energy applications in mind.
+          - Remote sensing and ML for seasonal snow; contributed to reproducible research workflows and open-source tooling.
 
-    - title: B.Sc. Geodesy & Geomatics
-      institution: Southwest Petroleum University (China)
-      year: 2010 - 2014
-      description:
-        - "Thesis: A WebGIS system for urban infrastructure management."
+    Skills:
+      - name: Programming
+        keywords: Python, SQL, Git
+      - name: ML & Statistics
+        keywords: Bayesian inference, Kalman filtering, machine learning, evaluation under uncertainty
+      - name: Data & Engineering
+        keywords: FastAPI, PostgreSQL, Docker, ETL, REST APIs
+      - name: Geospatial
+        keywords: Xarray, GeoPandas, Rasterio, Shapely, GIS automation
+      - name: Domains
+        keywords: CCUS, AI Agent, climate and energy datasets, remote sensing, geophysical data
 
-- title: Publications, Workshops and Patents
-  layer: additional
-  type: nested_list
-  contents:
-    - title: AI Agent for Climate and Energy
-      items:
-        - "AI Agent in CCUS: Toward autonomous MRV and cluster monitoring · In Progress · 2026."
-    - title: Cryosphere x Remote Sensing
-      items:
-        - Retrieving snow depth distribution by downscaling ERA5 reanalysis with ICESat-2 laser altimetry · Cold Regions Science and Technology · 2025.
-        - Snow depth retrieval and downscaling using satellite laser altimetry, machine learning and climate reanalysis · IUGG 2023 Berlin · 2023.
-        - Unlocking the Secrets of Snow Depth · Student presentation at SDG Conference (UiO) · 2023.
-    - title: Offshore / Geophysics
-      items:
-        - An identification system for underwater seismic devices · Patent (PRC) · 2022.
-        - Offshoreorient v1.0 · Software Copyright · 2020.
+    Education:
+      - institution: University of Oslo
+        location: Norway
+        area: Geoscience
+        studyType: M.Sc.
+        start_date: 2021
+        end_date: 2023
+        score: GPA 3.9/4.0
+        highlights:
+          - "Thesis: Snow depth retrieval and downscaling using satellite laser altimetry, machine learning, and climate reanalysis."
 
-- title: Additional Experience & Volunteering
-  layer: additional
-  type: time_table
-  contents:
-    - title: Geomatics Engineer & Assistant Project Manager
-      institution: BGP CNPC
-      year: 2014.07 - 2021.07
-      description:
-        - Delivered offshore geophysical survey data products; built QC/reporting automation to reduce manual workload.
-        - Licensed Registered Surveyor (2018); promoted to Assistant Project Manager (2021).
+      - institution: Southwest Petroleum University
+        location: China
+        area: Geodesy & Geomatics
+        studyType: B.Sc.
+        start_date: 2010
+        end_date: 2014
+        highlights:
+          - "Thesis: A WebGIS system for urban infrastructure management."
 
-    - title: Summer Research Assistant
-      year: 2023.05 - 2023.07
-      description:
-        - Bias correction and spatial downscaling of weather/climate datasets for energy-system modeling.
+    Publications:
+      - title: "AI Agent in CCUS: Toward autonomous MRV and cluster monitoring"
+        authors:
+          - Zhihao Liu
+        publisher: In Progress
+        releaseDate: 2026
+        summary: AI Agent for Climate and Energy.
 
-    - title: Teaching Assistant (Geophysical Data Science)
-      year: 2023
-      description:
-        - Taught Python labs and supported students with scientific programming and data analysis workflows.
+      - title: Retrieving snow depth distribution by downscaling ERA5 reanalysis with ICESat-2 laser altimetry
+        authors:
+          - Zhihao Liu
+        publisher: Cold Regions Science and Technology
+        releaseDate: 2025
+        summary: Cryosphere remote sensing and machine learning.
 
-- title: Other Interests
-  layer: additional
-  type: list
-  contents:
-    - Writing on climate change and energy transition.
-    - Endurance sports (running, skiing).
-    - Open source geospatial tooling and scientific workflows.
+      - title: Snow depth retrieval and downscaling using satellite laser altimetry, machine learning and climate reanalysis
+        authors:
+          - Zhihao Liu
+        publisher: IUGG 2023 Berlin
+        releaseDate: 2023
+
+      - title: Unlocking the Secrets of Snow Depth
+        authors:
+          - Zhihao Liu
+        publisher: Student presentation at SDG Conference, University of Oslo
+        releaseDate: 2023
+
+      - title: An identification system for underwater seismic devices
+        authors:
+          - Zhihao Liu
+        publisher: Patent, PRC
+        releaseDate: 2022
+
+      - title: Offshoreorient v1.0
+        authors:
+          - Zhihao Liu
+        publisher: Software Copyright
+        releaseDate: 2020
+
+    Additional Experience & Volunteering:
+      - company: BGP CNPC
+        position: Geomatics Engineer & Assistant Project Manager
+        start_date: 2014-07
+        end_date: 2021-07
+        highlights:
+          - Delivered offshore geophysical survey data products; built QC/reporting automation to reduce manual workload.
+          - Licensed Registered Surveyor (2018); promoted to Assistant Project Manager (2021).
+
+      - company: University of Oslo
+        position: Summer Research Assistant
+        location: Oslo, Norway
+        start_date: 2023-05
+        end_date: 2023-07
+        summary: Bias correction and spatial downscaling of weather/climate datasets for energy-system modeling.
+
+      - company: University of Oslo
+        position: Teaching Assistant (Geophysical Data Science)
+        location: Oslo, Norway
+        start_date: 2023
+        end_date: 2023
+        summary: Taught Python labs and supported students with scientific programming and data analysis workflows.
+
+    Interests:
+      - name: Writing
+        keywords: climate change, energy transition
+      - name: Endurance sports
+        keywords: running, skiing
+      - name: Open source
+        keywords: geospatial tooling, scientific workflows

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -31,16 +31,84 @@ home_cta: true
 _styles: >
   .home-proof {
     display: grid;
-    gap: 1rem;
-    margin-top: 2rem;
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+    margin: 2.5rem 0 3.5rem;
+  }
+  @media (min-width: 768px) {
+    .home-proof {
+      grid-template-columns: repeat(3, 1fr);
+      grid-template-rows: auto auto;
+    }
   }
   .home-proof__item {
-    border-left: 3px solid var(--global-theme-color);
-    padding-left: 1rem;
+    padding: 1.75rem 1.5rem;
+    border: 1px solid var(--global-divider-color);
+    background: var(--global-bg-color);
+    border-radius: 8px;
+    position: relative;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .home-proof__item:hover {
+    border-color: var(--global-theme-color);
+    transform: translateY(-3px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.06);
+  }
+  @media (min-width: 768px) {
+    .home-proof__item--large {
+      grid-column: span 2;
+      grid-row: span 2;
+      padding: 2.25rem 2rem;
+    }
+  }
+  .home-proof .data-tag {
+    font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--global-theme-color);
+    margin-bottom: 1.25rem;
+    display: inline-block;
+    padding: 0.25rem 0.6rem;
+    background: color-mix(in srgb, var(--global-theme-color) 8%, transparent);
+    border-radius: 4px;
+    width: fit-content;
+    border: 1px solid color-mix(in srgb, var(--global-theme-color) 15%, transparent);
   }
   .home-proof__item h2 {
-    font-size: 1.05rem;
-    margin-bottom: 0.35rem;
+    font-size: 1.35rem;
+    margin: 0 0 1rem 0;
+    color: var(--global-text-color);
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-weight: 700;
+  }
+  .home-proof__item h2 i {
+    font-size: 1.15rem;
+    color: var(--global-theme-color);
+  }
+  .home-proof__item p {
+    margin-bottom: 0;
+    font-size: 1rem;
+    line-height: 1.65;
+    color: var(--global-text-color);
+    opacity: 0.92;
+  }
+  .home-proof__item p a {
+    color: var(--global-theme-color);
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+  html[data-theme='dark'] .home-proof__item {
+    background: var(--global-card-bg-color);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   }
 ---
 
@@ -48,15 +116,18 @@ Throughout my career, I've worked at the intersection of climate, geospatial dat
 I build reusable decision tools from climate and geophysical data, with a bias toward workflows that can be reviewed, reproduced, and shipped.
 
 <div class="home-proof">
-  <div class="home-proof__item">
+  <div class="home-proof__item home-proof__item--large">
+    <span class="data-tag">CORE PILLAR 01</span>
     <h2><i class="fa-solid fa-graduation-cap"></i> Research Credibility</h2>
     <p>Peer-reviewed work on satellite laser altimetry and snow modeling (2025). High-precision geophysical modeling for remote and harsh environments. See <a href="{{ '/publications/' | relative_url }}">publications</a>.</p>
   </div>
   <div class="home-proof__item">
+    <span class="data-tag">CORE PILLAR 02</span>
     <h2><i class="fa-solid fa-bolt"></i> Climate & Energy</h2>
     <p>At the intersection of ML and energy assets: from 4D seismic monitoring for CCUS/Reservoirs to bias correction for climate-energy datasets.</p>
   </div>
   <div class="home-proof__item">
+    <span class="data-tag">CORE PILLAR 03</span>
     <h2><i class="fa-solid fa-rocket"></i> Shipping Ability</h2>
     <p>Building shippable decision tools: from Bayesian Models to AI Agents, with a focus on reproducibility and production-ready code.</p>
   </div>

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -11,6 +11,7 @@ nav_order: 3
 ## GitHub users
 
 {% if site.data.repositories.github_users %}
+
 <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
   {% for user in site.data.repositories.github_users %}
     {% include repository/repo_user.liquid username=user %}
@@ -21,14 +22,15 @@ nav_order: 3
 
 {% if site.repo_trophies.enabled %}
 {% for user in site.data.repositories.github_users %}
-  {% if site.data.repositories.github_users.size > 1 %}
+{% if site.data.repositories.github_users.size > 1 %}
+
   <h4>{{ user }}</h4>
   {% endif %}
   <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
   {% include repository/repo_trophies.liquid username=user %}
   </div>
 
-  ---
+---
 
 {% endfor %}
 {% endif %}
@@ -37,6 +39,13 @@ nav_order: 3
 ## GitHub Repositories
 
 {% if site.data.repositories.github_repos %}
+
+<ul class="repo-links">
+  {% for repo in site.data.repositories.github_repos %}
+    <li><a href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">{{ repo }}</a></li>
+  {% endfor %}
+</ul>
+
 <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
   {% for repo in site.data.repositories.github_repos %}
     {% include repository/repo.liquid repository=repo %}

--- a/cv.md
+++ b/cv.md
@@ -2,20 +2,11 @@
 layout: cv
 permalink: /cv/
 title: CV
-nav: false
-nav_order: 5
-cv_pdf: CV_Zhihao_geoscience.pdf
+nav: true
+nav_order: 4
+cv_pdf: /assets/pdf/CV_Zhihao_geoscience.pdf
+cv_format: rendercv
 description: "Climate & Energy Data Scientist | Caixin ESG30 Young Scholar"
 toc:
   sidebar: left
 ---
-
-<div class="post">
-  <header class="post-header">
-    <div class="float-right">
-      <a href="{{ '/assets/pdf/' | append: page.cv_pdf | relative_url }}" target="_blank" class="btn btn-outline-primary btn-sm">
-        <i class="fas fa-file-pdf"></i> Download PDF
-      </a>
-    </div>
-  </header>
-</div>


### PR DESCRIPTION
## Summary
- restore the homepage proof-block visual details from the pre-v1 optimization branch using page-level styles
- convert CV data to the al-folio v1 RenderCV-shaped data contract and restore CV navigation/PDF path
- add a plain GitHub repository link fallback so the repositories page is not empty when external stats cards fail
- restore previous site metadata keys kept by the local site customizations

## Verification
- python YAML parse for _data/cv.yml
- npx prettier --check _pages/about.md _pages/repositories.md cv.md _data/cv.yml _config.yml
- npm run lint:style-contract
- git diff --check

Note: local Ruby/Bundler is unavailable in this Windows environment, so full Jekyll build is left to GitHub Actions.