### PR TITLE
Refine homepage, CV, and repositories presentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -86,10 +86,10 @@ al_folio:
 
 navbar_fixed: true
 footer_fixed: false
-search_enabled: true
-socials_in_search: true
-posts_in_search: true
-bib_search: true
+search_enabled: false
+socials_in_search: false
+posts_in_search: false
+bib_search: false
 
 # Dimensions
 max_width: 920px

--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -4,7 +4,6 @@ cv:
   email: zhihaol[at]uio.com
   location: Oslo / Bergen, Norway
   image: ""
-  summary: Climate and energy data scientist building uncertainty-aware, reproducible ML workflows and decision tools from climate, geospatial, and geophysical data.
 
   social_networks:
     - network: GitHub
@@ -13,24 +12,17 @@ cv:
       username: liuzhihao
 
   sections:
-    Summary:
-      - name: Focus
-        summary: AI Agent for Energy & Climate
-      - name: Strengths
-        summary: Uncertainty-aware modeling, specializing in the digitalization of MRV and 4D seismic monitoring for CCUS cluster governance.
-      - name: Book a chat
-        url: https://calendar.app.google/UQ267iEs4MTAGFSd7
-        summary: Google Calendar
-
     Experience:
       - company: BGP CNPC
         position: Business Development Manager (New Energy)
+        location: China
         start_date: 2024-07
         end_date: present
         summary: Client-facing work translating technical constraints into commercial proposals and delivery plans; architecting Digital Carbon Monitoring & MRV frameworks to strengthen a data-to-decision mindset.
 
       - company: LIU GEOCONSULTING
         position: Principal
+        location: Norway
         start_date: 2023-12
         end_date: 2024-06
         highlights:
@@ -46,18 +38,6 @@ cv:
         highlights:
           - Bias correction and spatial downscaling workflows for climate/weather data with energy applications in mind.
           - Remote sensing and ML for seasonal snow; contributed to reproducible research workflows and open-source tooling.
-
-    Skills:
-      - name: Programming
-        keywords: Python, SQL, Git
-      - name: ML & Statistics
-        keywords: Bayesian inference, Kalman filtering, machine learning, evaluation under uncertainty
-      - name: Data & Engineering
-        keywords: FastAPI, PostgreSQL, Docker, ETL, REST APIs
-      - name: Geospatial
-        keywords: Xarray, GeoPandas, Rasterio, Shapely, GIS automation
-      - name: Domains
-        keywords: CCUS, AI Agent, climate and energy datasets, remote sensing, geophysical data
 
     Education:
       - institution: University of Oslo
@@ -79,14 +59,7 @@ cv:
         highlights:
           - "Thesis: A WebGIS system for urban infrastructure management."
 
-    Publications:
-      - title: "AI Agent in CCUS: Toward autonomous MRV and cluster monitoring"
-        authors:
-          - Zhihao Liu
-        publisher: In Progress
-        releaseDate: 2026
-        summary: AI Agent for Climate and Energy.
-
+    "Publications & Patent":
       - title: Retrieving snow depth distribution by downscaling ERA5 reanalysis with ICESat-2 laser altimetry
         authors:
           - Zhihao Liu
@@ -118,33 +91,14 @@ cv:
         publisher: Software Copyright
         releaseDate: 2020
 
-    Additional Experience & Volunteering:
-      - company: BGP CNPC
-        position: Geomatics Engineer & Assistant Project Manager
-        start_date: 2014-07
-        end_date: 2021-07
-        highlights:
-          - Delivered offshore geophysical survey data products; built QC/reporting automation to reduce manual workload.
-          - Licensed Registered Surveyor (2018); promoted to Assistant Project Manager (2021).
-
-      - company: University of Oslo
-        position: Summer Research Assistant
-        location: Oslo, Norway
-        start_date: 2023-05
-        end_date: 2023-07
-        summary: Bias correction and spatial downscaling of weather/climate datasets for energy-system modeling.
-
-      - company: University of Oslo
-        position: Teaching Assistant (Geophysical Data Science)
-        location: Oslo, Norway
-        start_date: 2023
-        end_date: 2023
-        summary: Taught Python labs and supported students with scientific programming and data analysis workflows.
-
-    Interests:
-      - name: Writing
-        keywords: climate change, energy transition
-      - name: Endurance sports
-        keywords: running, skiing
-      - name: Open source
-        keywords: geospatial tooling, scientific workflows
+    Skills:
+      - name: Programming
+        keywords: Python, SQL, Git
+      - name: ML & Statistics
+        keywords: Bayesian inference, Kalman filtering, machine learning, evaluation under uncertainty
+      - name: Data & Engineering
+        keywords: FastAPI, PostgreSQL, Docker, ETL, REST APIs
+      - name: Geospatial
+        keywords: Xarray, GeoPandas, Rasterio, Shapely, GIS automation
+      - name: Domains
+        keywords: CCUS, climate and energy datasets, remote sensing, geophysical data

--- a/_data/socials.yml
+++ b/_data/socials.yml
@@ -1,9 +1,8 @@
 # Social links displayed by jekyll-socials in al-folio v1.
-cv_pdf: /assets/pdf/CV_Zhihao_geoscience.pdf
-email: zhihaol[at]uio.com
+custom_social:
+  logo: /assets/img/cv-icon.svg
+  title: CV
+  url: /cv/
 github_username: liuh886
 linkedin_username: liuzhihao
-orcid_id: 0000-0002-4996-2521
 rss_icon: false
-scholar_userid: usxQ4tcAAAAJ
-x_username: liuh886qw

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -26,23 +26,51 @@ latest_posts:
 selected_papers: true # includes a list of papers marked as "selected={true}"
 projects: false # includes projects
 display_categories: [work] # Projects show in about page
-social: true # includes social icons at the bottom of the page
+social: true # rendered from _data/socials.yml
 home_cta: true
 _styles: >
+  .home-intro {
+    max-width: 42rem;
+  }
+  .home-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 1.5rem 0 2rem;
+  }
+  .home-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 8px;
+    padding: 0.58rem 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid var(--global-divider-color);
+    color: var(--global-text-color);
+    background: var(--global-bg-color);
+  }
+  .home-actions a:first-child {
+    border-color: var(--global-theme-color);
+    color: var(--global-theme-color);
+  }
+  .home-actions a:hover {
+    border-color: var(--global-theme-color);
+    color: var(--global-theme-color);
+  }
   .home-proof {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 1.25rem;
-    margin: 2.5rem 0 3.5rem;
+    gap: 0.85rem;
+    margin: 2.1rem 0 2.75rem;
   }
   @media (min-width: 768px) {
     .home-proof {
       grid-template-columns: repeat(3, 1fr);
-      grid-template-rows: auto auto;
     }
   }
   .home-proof__item {
-    padding: 1.75rem 1.5rem;
+    padding: 1.2rem 1.1rem;
     border: 1px solid var(--global-divider-color);
     background: var(--global-bg-color);
     border-radius: 8px;
@@ -51,54 +79,33 @@ _styles: >
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     display: flex;
     flex-direction: column;
-    overflow: hidden;
   }
   .home-proof__item:hover {
     border-color: var(--global-theme-color);
-    transform: translateY(-3px);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.06);
-  }
-  @media (min-width: 768px) {
-    .home-proof__item--large {
-      grid-column: span 2;
-      grid-row: span 2;
-      padding: 2.25rem 2rem;
-    }
-  }
-  .home-proof .data-tag {
-    font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--global-theme-color);
-    margin-bottom: 1.25rem;
-    display: inline-block;
-    padding: 0.25rem 0.6rem;
-    background: color-mix(in srgb, var(--global-theme-color) 8%, transparent);
-    border-radius: 4px;
-    width: fit-content;
-    border: 1px solid color-mix(in srgb, var(--global-theme-color) 15%, transparent);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.055);
   }
   .home-proof__item h2 {
-    font-size: 1.35rem;
-    margin: 0 0 1rem 0;
+    font-size: 1.05rem;
+    margin: 0 0 0.55rem 0;
     color: var(--global-text-color);
     display: flex;
     align-items: center;
-    gap: 0.6rem;
-    font-weight: 700;
+    gap: 0.5rem;
+    font-weight: 650;
   }
   .home-proof__item h2 i {
-    font-size: 1.15rem;
+    font-size: 0.9rem;
     color: var(--global-theme-color);
+    width: 1rem;
+    text-align: center;
   }
   .home-proof__item p {
     margin-bottom: 0;
-    font-size: 1rem;
-    line-height: 1.65;
+    font-size: 0.95rem;
+    line-height: 1.58;
     color: var(--global-text-color);
-    opacity: 0.92;
+    opacity: 0.86;
   }
   .home-proof__item p a {
     color: var(--global-theme-color);
@@ -112,22 +119,26 @@ _styles: >
   }
 ---
 
-Throughout my career, I've worked at the intersection of climate, geospatial data, and applied machine learning.
-I build reusable decision tools from climate and geophysical data, with a bias toward workflows that can be reviewed, reproduced, and shipped.
+<div class="home-intro">
+  <p>Throughout my career, I've worked at the intersection of climate, geospatial data, and applied machine learning.</p>
+  <p>I build reusable decision tools from climate and geophysical data, with a bias toward workflows that can be reviewed, reproduced, and shipped.</p>
+</div>
+
+<div class="home-actions">
+  <a href="https://calendar.app.google/UQ267iEs4MTAGFSd7" target="_blank" rel="noopener noreferrer"><i class="fa-regular fa-calendar"></i> Book a chat</a>
+  <a href="{{ '/projects/' | relative_url }}"><i class="fa-solid fa-diagram-project"></i> Portfolio</a>
+</div>
 
 <div class="home-proof">
-  <div class="home-proof__item home-proof__item--large">
-    <span class="data-tag">CORE PILLAR 01</span>
+  <div class="home-proof__item">
     <h2><i class="fa-solid fa-graduation-cap"></i> Research Credibility</h2>
     <p>Peer-reviewed work on satellite laser altimetry and snow modeling (2025). High-precision geophysical modeling for remote and harsh environments. See <a href="{{ '/publications/' | relative_url }}">publications</a>.</p>
   </div>
   <div class="home-proof__item">
-    <span class="data-tag">CORE PILLAR 02</span>
     <h2><i class="fa-solid fa-bolt"></i> Climate & Energy</h2>
     <p>At the intersection of ML and energy assets: from 4D seismic monitoring for CCUS/Reservoirs to bias correction for climate-energy datasets.</p>
   </div>
   <div class="home-proof__item">
-    <span class="data-tag">CORE PILLAR 03</span>
     <h2><i class="fa-solid fa-rocket"></i> Shipping Ability</h2>
     <p>Building shippable decision tools: from Bayesian Models to AI Agents, with a focus on reproducibility and production-ready code.</p>
   </div>

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 permalink: /blog/
-title: blog
+title: Blog
 nav: true
 nav_order: 2
 pagination:

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -6,49 +6,161 @@ nav_title: repositories
 description: Selected open-source repositories and code projects.
 nav: true
 nav_order: 3
+_styles: >
+  .repo-section {
+    margin-top: 1.5rem;
+  }
+  .repo-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.9rem;
+    margin: 1rem 0 2rem;
+  }
+  @media (min-width: 768px) {
+    .repo-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .repo-profile,
+  .repo-card {
+    border: 1px solid var(--global-divider-color);
+    border-radius: 8px;
+    background: var(--global-bg-color);
+    padding: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  }
+  .repo-profile:hover,
+  .repo-card:hover {
+    border-color: var(--global-theme-color);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.06);
+  }
+  html[data-theme='dark'] .repo-profile,
+  html[data-theme='dark'] .repo-card {
+    background: var(--global-card-bg-color);
+  }
+  .repo-profile {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+  }
+  .repo-profile img {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 8px;
+    border: 1px solid var(--global-divider-color);
+  }
+  .repo-profile h3,
+  .repo-card h3 {
+    margin: 0;
+    font-size: 1.05rem;
+  }
+  .repo-profile p,
+  .repo-card p {
+    margin: 0.25rem 0 0;
+    color: var(--global-text-color);
+    opacity: 0.72;
+    font-size: 0.92rem;
+  }
+  .repo-card__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+  .repo-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-top: 0.85rem;
+  }
+  .repo-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border: 1px solid var(--global-divider-color);
+    border-radius: 999px;
+    padding: 0.22rem 0.55rem;
+    font-size: 0.82rem;
+    color: var(--global-text-color);
+    opacity: 0.78;
+  }
+  .repo-card__link {
+    color: var(--global-theme-color);
+    white-space: nowrap;
+  }
+  .repo-card__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.9rem;
+    color: var(--global-theme-color);
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .repo-card__stats {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    margin-top: 0.85rem;
+    border-radius: 6px;
+  }
 ---
-
-## GitHub users
 
 {% if site.data.repositories.github_users %}
 
-<div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
+## GitHub users
+
+<div class="repo-grid repo-section">
   {% for user in site.data.repositories.github_users %}
-    {% include repository/repo_user.liquid username=user %}
+    <a class="repo-profile" href="https://github.com/{{ user }}" target="_blank" rel="noopener noreferrer">
+      <img src="https://github.com/{{ user }}.png?size=160" alt="{{ user }} GitHub avatar" loading="lazy">
+      <span>
+        <h3><i class="fa-brands fa-github"></i> {{ user }}</h3>
+        <p>GitHub profile</p>
+      </span>
+    </a>
   {% endfor %}
 </div>
 
----
-
-{% if site.repo_trophies.enabled %}
-{% for user in site.data.repositories.github_users %}
-{% if site.data.repositories.github_users.size > 1 %}
-
-  <h4>{{ user }}</h4>
-  {% endif %}
-  <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
-  {% include repository/repo_trophies.liquid username=user %}
-  </div>
-
----
-
-{% endfor %}
 {% endif %}
-{% endif %}
-
-## GitHub Repositories
 
 {% if site.data.repositories.github_repos %}
 
-<ul class="repo-links">
-  {% for repo in site.data.repositories.github_repos %}
-    <li><a href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">{{ repo }}</a></li>
-  {% endfor %}
-</ul>
+## GitHub Repositories
 
-<div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
+<div class="repo-grid repo-section">
   {% for repo in site.data.repositories.github_repos %}
-    {% include repository/repo.liquid repository=repo %}
+    {% assign repo_parts = repo | split: "/" %}
+    {% assign owner = repo_parts[0] %}
+    {% assign name = repo_parts[1] %}
+    <article class="repo-card">
+      <div class="repo-card__top">
+        <div>
+          <h3>{{ name }}</h3>
+          <p>{{ owner }}</p>
+        </div>
+        <a class="repo-card__link" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ repo }} on GitHub">
+          <i class="fa-brands fa-github"></i>
+        </a>
+      </div>
+      <div class="repo-card__meta">
+        <span class="repo-chip"><i class="fa-solid fa-code-branch"></i> Repository</span>
+        <span class="repo-chip">{{ owner }}/{{ name }}</span>
+      </div>
+      <a class="repo-card__cta" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">View repository <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+      <a href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">
+        <img
+          class="repo-card__stats"
+          src="{{ site.external_services.github_readme_stats_url }}/api/pin/?username={{ owner }}&repo={{ name }}&theme=transparent&show_owner=true"
+          alt="{{ repo }} repository stats"
+          loading="lazy"
+          onerror="this.style.display='none'"
+        >
+      </a>
+    </article>
   {% endfor %}
 </div>
+
 {% endif %}

--- a/assets/img/cv-icon.svg
+++ b/assets/img/cv-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="CV">
+  <rect x="14" y="8" width="36" height="48" rx="4" fill="none" stroke="#555555" stroke-width="4"/>
+  <path d="M22 22h20M22 32h20M22 42h12" fill="none" stroke="#555555" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/cv.md
+++ b/cv.md
@@ -9,4 +9,45 @@ cv_format: rendercv
 description: "Climate & Energy Data Scientist | Caixin ESG30 Young Scholar"
 toc:
   sidebar: left
+_styles: >
+  .post-header .post-title {
+    margin-bottom: 0.25rem;
+  }
+  .post-header .desc {
+    font-size: 1rem;
+    opacity: 0.76;
+  }
+  .cv .card {
+    border: 1px solid var(--global-divider-color);
+    border-radius: 8px;
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.04);
+    padding: 1.15rem !important;
+  }
+  html[data-theme='dark'] .cv .card {
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.22);
+  }
+  .cv .card-title {
+    margin-bottom: 0.9rem;
+    font-size: 1.12rem;
+    letter-spacing: 0;
+  }
+  .cv .list-group-item {
+    border-color: var(--global-divider-color);
+    padding: 0.95rem 0;
+  }
+  .cv .badge {
+    border-radius: 6px;
+    letter-spacing: 0;
+    text-transform: none !important;
+  }
+  .cv h6.title {
+    font-size: 1rem;
+    line-height: 1.35;
+  }
+  .cv ul.items {
+    margin-top: 0.45rem;
+  }
+  .cv ul.items li {
+    margin-bottom: 0.25rem;
+  }
 ---


### PR DESCRIPTION
## Summary
- simplify CV content: remove Summary, AI Agent in CCUS, Additional Experience & Volunteering, and Interests; move Skills to the bottom and rename Publications to Publications & Patent
- refine homepage proof cards, remove CORE PILLAR labels, restore Book a chat and Portfolio CTAs
- use theme social output with only CV page, LinkedIn, and GitHub
- disable the Ctrl-K search entry and rename nav blog to Blog
- rebuild repositories as reliable local cards while keeping GitHub stats images as optional enhancement

## Verification
- python YAML/data assertions for CV section order and socials data
- npx prettier --check for touched liquid/yaml files
- npm run lint:style-contract
- git diff --check
- frontend review pass via subagent; addressed repo image fallback and CV icon contrast findings