### PR TITLE
Polish homepage socials and CV rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,8 +7,7 @@ first_name: Zhihao
 middle_name:
 last_name: LIU
 tab_title: "Zhihao LIU | Climate & Energy Data Scientist" # preserves the previous browser-tab title customization
-contact_note: >
-  feel free to reach me.
+contact_note:
 description: >
   Climate & energy data scientist building reproducible ML workflows and decision tools from climate and geospatial data.
 footer_text: >

--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -59,12 +59,37 @@ cv:
         highlights:
           - "Thesis: A WebGIS system for urban infrastructure management."
 
-    "Publications & Patent":
-      - "Retrieving snow depth distribution by downscaling ERA5 reanalysis with ICESat-2 laser altimetry - Cold Regions Science and Technology, 2025."
-      - "Snow depth retrieval and downscaling using satellite laser altimetry, machine learning and climate reanalysis - IUGG 2023 Berlin, 2023."
-      - "Unlocking the Secrets of Snow Depth - Student presentation at SDG Conference, University of Oslo, 2023."
-      - "An identification system for underwater seismic devices - Patent, PRC, 2022."
-      - "Offshoreorient v1.0 - Software Copyright, 2020."
+    Publications:
+      - title: Retrieving snow depth distribution by downscaling ERA5 reanalysis with ICESat-2 laser altimetry
+        authors:
+          - Zhihao Liu
+        publisher: Cold Regions Science and Technology
+        releaseDate: 2025
+        summary: Cryosphere remote sensing and machine learning.
+
+      - title: Snow depth retrieval and downscaling using satellite laser altimetry, machine learning and climate reanalysis
+        authors:
+          - Zhihao Liu
+        publisher: IUGG 2023 Berlin
+        releaseDate: 2023
+
+      - title: Unlocking the Secrets of Snow Depth
+        authors:
+          - Zhihao Liu
+        publisher: Student presentation at SDG Conference, University of Oslo
+        releaseDate: 2023
+
+      - title: An identification system for underwater seismic devices
+        authors:
+          - Zhihao Liu
+        publisher: Patent, PRC
+        releaseDate: 2022
+
+      - title: Offshoreorient v1.0
+        authors:
+          - Zhihao Liu
+        publisher: Software Copyright
+        releaseDate: 2020
 
     Skills:
       - name: Programming

--- a/_data/socials.yml
+++ b/_data/socials.yml
@@ -1,8 +1,7 @@
 # Social links displayed by jekyll-socials in al-folio v1.
 custom_social:
-  logo: /assets/img/cv-icon.svg
+  logo: cv-social-text
   title: CV
   url: /cv/
 github_username: liuh886
 linkedin_username: liuzhihao
-rss_icon: false

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -32,90 +32,87 @@ _styles: >
   .home-intro {
     max-width: 42rem;
   }
-  .home-actions {
+  .home-links {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
-    margin: 1.5rem 0 2rem;
-  }
-  .home-actions a {
-    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    border-radius: 8px;
-    padding: 0.58rem 0.9rem;
+    gap: 0.45rem;
+    margin: 1.15rem 0 2.2rem;
+    color: var(--global-text-color-light);
+    font-size: 0.95rem;
+  }
+  .home-links a {
+    color: var(--global-theme-color);
     font-weight: 600;
     text-decoration: none;
-    border: 1px solid var(--global-divider-color);
-    color: var(--global-text-color);
-    background: var(--global-bg-color);
   }
-  .home-actions a:first-child {
-    border-color: var(--global-theme-color);
-    color: var(--global-theme-color);
-  }
-  .home-actions a:hover {
-    border-color: var(--global-theme-color);
-    color: var(--global-theme-color);
-  }
-  .home-proof {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 0.85rem;
-    margin: 2.1rem 0 2.75rem;
-  }
-  @media (min-width: 768px) {
-    .home-proof {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-  .home-proof__item {
-    padding: 1.2rem 1.1rem;
-    border: 1px solid var(--global-divider-color);
-    background: var(--global-bg-color);
-    border-radius: 8px;
-    position: relative;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-    display: flex;
-    flex-direction: column;
-  }
-  .home-proof__item:hover {
-    border-color: var(--global-theme-color);
-    transform: translateY(-2px);
-    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.055);
-  }
-  .home-proof__item h2 {
-    font-size: 1.05rem;
-    margin: 0 0 0.55rem 0;
-    color: var(--global-text-color);
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-weight: 650;
-  }
-  .home-proof__item h2 i {
-    font-size: 0.9rem;
-    color: var(--global-theme-color);
-    width: 1rem;
-    text-align: center;
-  }
-  .home-proof__item p {
-    margin-bottom: 0;
-    font-size: 0.95rem;
-    line-height: 1.58;
-    color: var(--global-text-color);
-    opacity: 0.86;
-  }
-  .home-proof__item p a {
-    color: var(--global-theme-color);
-    font-weight: 600;
+  .home-links a:hover {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
-  html[data-theme='dark'] .home-proof__item {
-    background: var(--global-card-bg-color);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  .home-links span {
+    opacity: 0.45;
+  }
+  .home-focus {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+    margin: 1.9rem 0 2.85rem;
+    max-width: 48rem;
+    border-top: 1px solid var(--global-divider-color);
+  }
+  .home-focus__item {
+    display: grid;
+    grid-template-columns: minmax(7.5rem, 0.34fr) 1fr;
+    gap: 1rem;
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--global-divider-color);
+  }
+  .home-focus__label {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    font-weight: 700;
+    color: var(--global-text-color);
+    text-transform: uppercase;
+  }
+  .home-focus__item p {
+    margin-bottom: 0;
+    font-size: 0.95rem;
+    line-height: 1.62;
+    color: var(--global-text-color);
+  }
+  .home-focus__item p a {
+    color: var(--global-theme-color);
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .home-focus__item p a:hover {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+  .contact-icons .cv-social-text::before {
+    content: 'CV';
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25em;
+    font-size: 0.82em;
+    font-weight: 700;
+    letter-spacing: 0;
+    line-height: 1;
+  }
+  .contact-icons a[title='Rss icon'] {
+    display: none !important;
+  }
+  .contact-note {
+    display: none;
+  }
+  @media (max-width: 575px) {
+    .home-focus__item {
+      grid-template-columns: 1fr;
+      gap: 0.25rem;
+    }
   }
 ---
 
@@ -124,22 +121,25 @@ _styles: >
   <p>I build reusable decision tools from climate and geophysical data, with a bias toward workflows that can be reviewed, reproduced, and shipped.</p>
 </div>
 
-<div class="home-actions">
-  <a href="https://calendar.app.google/UQ267iEs4MTAGFSd7" target="_blank" rel="noopener noreferrer"><i class="fa-regular fa-calendar"></i> Book a chat</a>
-  <a href="{{ '/projects/' | relative_url }}"><i class="fa-solid fa-diagram-project"></i> Portfolio</a>
+<div class="home-links" aria-label="Selected links">
+  <a href="https://calendar.app.google/UQ267iEs4MTAGFSd7" target="_blank" rel="noopener noreferrer">Book a chat</a>
+  <span>/</span>
+  <a href="{{ '/portfolio/' | relative_url }}">Market Insights</a>
+  <span>/</span>
+  <a href="{{ '/cv/' | relative_url }}">CV</a>
 </div>
 
-<div class="home-proof">
-  <div class="home-proof__item">
-    <h2><i class="fa-solid fa-graduation-cap"></i> Research Credibility</h2>
+<div class="home-focus">
+  <div class="home-focus__item">
+    <p class="home-focus__label">Research</p>
     <p>Peer-reviewed work on satellite laser altimetry and snow modeling (2025). High-precision geophysical modeling for remote and harsh environments. See <a href="{{ '/publications/' | relative_url }}">publications</a>.</p>
   </div>
-  <div class="home-proof__item">
-    <h2><i class="fa-solid fa-bolt"></i> Climate & Energy</h2>
+  <div class="home-focus__item">
+    <p class="home-focus__label">Climate & Energy</p>
     <p>At the intersection of ML and energy assets: from 4D seismic monitoring for CCUS/Reservoirs to bias correction for climate-energy datasets.</p>
   </div>
-  <div class="home-proof__item">
-    <h2><i class="fa-solid fa-rocket"></i> Shipping Ability</h2>
+  <div class="home-focus__item">
+    <p class="home-focus__label">Decision Tools</p>
     <p>Building shippable decision tools: from Bayesian Models to AI Agents, with a focus on reproducibility and production-ready code.</p>
   </div>
 </div>

--- a/_pages/portfolio.md
+++ b/_pages/portfolio.md
@@ -1,0 +1,322 @@
+---
+layout: page
+permalink: /portfolio/
+title: Market Insights
+description: Time-series observations on Energy, Tech, and Macroeconomics.
+nav: false
+nav_order: 5
+_styles: >
+  .portfolio-widgets {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+    margin-top: 1rem;
+  }
+  @media (min-width: 768px) {
+    .portfolio-widgets {
+      grid-template-columns: minmax(0, 1.45fr) minmax(20rem, 1fr);
+    }
+  }
+  .stock-widget {
+    overflow: hidden;
+  }
+  .stock-widget--story .tradingview-widget-container,
+  .stock-widget--analysis .tradingview-widget-container {
+    min-height: 520px;
+  }
+  .stock-widget--overview .tradingview-widget-container {
+    min-height: 420px;
+  }
+  html[data-theme='dark'] .stock-widget-light,
+  html:not([data-theme='dark']) .stock-widget-dark {
+    display: none;
+  }
+  .stock-analysis__selector {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+  .stock-analysis__label {
+    color: var(--global-text-color-light);
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+  .stock-analysis__buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .stock-analysis__pill {
+    border: 1px solid var(--global-divider-color);
+    background: transparent;
+    color: var(--global-text-color);
+    border-radius: 999px;
+    padding: 0.4rem 0.85rem;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+  }
+  .stock-analysis__pill:hover,
+  .stock-analysis__pill:focus-visible {
+    border-color: var(--global-theme-color);
+    color: var(--global-theme-color);
+    outline: none;
+  }
+  .stock-analysis__pill.is-active {
+    background: var(--global-theme-color);
+    color: var(--global-bg-color);
+    border-color: var(--global-theme-color);
+  }
+  .stock-analysis__panel {
+    display: none;
+  }
+  .stock-analysis__panel.is-active {
+    display: block;
+  }
+---
+
+While my primary work focuses on physical climate data, I maintain a keen interest in **financial time-series analysis**, particularly within the energy and technology sectors.
+
+Understanding market volatility and correlations is crucial for the energy transition. This dashboard serves as a sandbox where I monitor:
+
+- **Energy Economics:** The interplay between fossil fuel prices and renewable energy indices.
+- **Macro Trends:** Global indicators that influence climate policy and infrastructure investment.
+- **Data Patterns:** Observing real-time stochastic processes and market sentiment.
+
+---
+
+## Market pulse
+
+{% assign stocks = site.data.stocks %}
+{% assign stock_symbols = stocks.symbols | default: '' | split: ',' %}
+{% if stocks.symbols and stocks.symbols.size > 0 %}
+{% assign stock_symbols = stocks.symbols %}
+{% endif %}
+
+<div class="stock-widget my-4 stock-widget--ticker">
+  <div class="tradingview-widget-container stock-widget-light">
+    <div class="tradingview-widget-container__widget"></div>
+    <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-ticker-tape.js" async>
+      {
+        "symbols": [
+          {% for symbol in stock_symbols %}
+            {
+              "proName": "{{ symbol | escape }}",
+              "title": "{{ symbol | split: ':' | last }}"
+            }{% unless forloop.last %},{% endunless %}
+          {% endfor %}
+        ],
+        "showSymbolLogo": true,
+        "colorTheme": "light",
+        "isTransparent": false,
+        "displayMode": "regular",
+        "locale": "{{ stocks.locale | default: site.lang | default: 'en' }}"
+      }
+    </script>
+  </div>
+
+  <div class="tradingview-widget-container stock-widget-dark">
+    <div class="tradingview-widget-container__widget"></div>
+    <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-ticker-tape.js" async>
+      {
+        "symbols": [
+          {% for symbol in stock_symbols %}
+            {
+              "proName": "{{ symbol | escape }}",
+              "title": "{{ symbol | split: ':' | last }}"
+            }{% unless forloop.last %},{% endunless %}
+          {% endfor %}
+        ],
+        "showSymbolLogo": true,
+        "colorTheme": "dark",
+        "isTransparent": false,
+        "displayMode": "regular",
+        "locale": "{{ stocks.locale | default: site.lang | default: 'en' }}"
+      }
+    </script>
+  </div>
+</div>
+
+<div class="stock-widget stock-widget--overview my-4">
+  <div class="tradingview-widget-container stock-widget-light">
+    <div class="tradingview-widget-container__widget"></div>
+    <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-symbol-overview.js" async>
+      {
+        "symbols": [
+          {% for symbol in stock_symbols %}["{{ symbol | escape }}"]{% unless forloop.last %},{% endunless %}{% endfor %}
+        ],
+        "chartOnly": false,
+        "autosize": true,
+        "showVolume": false,
+        "showMA": false,
+        "colorTheme": "light",
+        "locale": "{{ stocks.locale | default: site.lang | default: 'en' }}",
+        "scalePosition": "right",
+        "scaleMode": "Normal",
+        "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', sans-serif",
+        "fontSize": "12",
+        "noTimeScale": false,
+        "valuesTracking": "1",
+        "changeMode": "price-and-percent",
+        "chartType": "area",
+        "lineWidth": 2,
+        "dateRanges": ["1d|1","1m|30","3m|60","1y|1D","5y|1W","all|1M"]
+      }
+    </script>
+  </div>
+
+  <div class="tradingview-widget-container stock-widget-dark">
+    <div class="tradingview-widget-container__widget"></div>
+    <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-symbol-overview.js" async>
+      {
+        "symbols": [
+          {% for symbol in stock_symbols %}["{{ symbol | escape }}"]{% unless forloop.last %},{% endunless %}{% endfor %}
+        ],
+        "chartOnly": false,
+        "autosize": true,
+        "showVolume": false,
+        "showMA": false,
+        "colorTheme": "dark",
+        "locale": "{{ stocks.locale | default: site.lang | default: 'en' }}",
+        "scalePosition": "right",
+        "scaleMode": "Normal",
+        "fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', sans-serif",
+        "fontSize": "12",
+        "noTimeScale": false,
+        "valuesTracking": "1",
+        "changeMode": "price-and-percent",
+        "chartType": "area",
+        "lineWidth": 2,
+        "dateRanges": ["1d|1","1m|30","3m|60","1y|1D","5y|1W","all|1M"]
+      }
+    </script>
+  </div>
+</div>
+
+## Market highlights
+
+<div class="portfolio-widgets">
+  <div class="portfolio-widgets__top-stories">
+    <div class="stock-widget my-4">
+      <div class="tradingview-widget-container stock-widget-light stock-widget--story">
+        <div class="tradingview-widget-container__widget"></div>
+        <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-timeline.js" async>
+          {
+            "feedMode": "all_symbols",
+            "isTransparent": false,
+            "displayMode": "regular",
+            "width": "100%",
+            "height": "480",
+            "colorTheme": "light",
+            "locale": "{{ stocks.locale | default: site.lang | default: 'en' }}"
+          }
+        </script>
+      </div>
+
+      <div class="tradingview-widget-container stock-widget-dark stock-widget--story">
+        <div class="tradingview-widget-container__widget"></div>
+        <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-timeline.js" async>
+          {
+            "feedMode": "all_symbols",
+            "isTransparent": false,
+            "displayMode": "regular",
+            "width": "100%",
+            "height": "480",
+            "colorTheme": "dark",
+            "locale": "{{ stocks.locale | default: site.lang | default: 'en' }}"
+          }
+        </script>
+      </div>
+    </div>
+
+  </div>
+  <div class="portfolio-widgets__analysis">
+    {% assign default_symbol = stock_symbols | first | default: 'NASDAQ:AAPL' %}
+    {% assign widget_id = 'analysis-' | append: page.url | slugify %}
+
+    <div class="stock-widget my-4">
+      <div class="stock-analysis__selector" data-analysis-tabs="{{ widget_id }}">
+        <span class="stock-analysis__label">Analyze</span>
+        <div class="stock-analysis__buttons">
+          {% for symbol in stock_symbols %}
+            <button class="stock-analysis__pill{% if symbol == default_symbol %} is-active{% endif %}" type="button" data-symbol="{{ symbol | escape }}">
+              {{ symbol | split: ':' | last }}
+            </button>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="stock-analysis" data-analysis-panels="{{ widget_id }}">
+        {% for symbol in stock_symbols %}
+          <div class="stock-analysis__panel{% if symbol == default_symbol %} is-active{% endif %}" data-analysis-panel="{{ widget_id }}" data-symbol="{{ symbol | escape }}">
+            <div class="tradingview-widget-container stock-widget-light stock-widget--analysis">
+              <div class="tradingview-widget-container__widget"></div>
+              <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-technical-analysis.js" async>
+                {
+                  "interval": "1D",
+                  "width": "100%",
+                  "isTransparent": false,
+                  "height": "480",
+                  "symbol": "{{ symbol | escape }}",
+                  "showIntervalTabs": true,
+                  "displayMode": "single",
+                  "colorTheme": "light",
+                  "locale": "{{ stocks.locale | default: site.lang | default: 'en' }}"
+                }
+              </script>
+            </div>
+
+            <div class="tradingview-widget-container stock-widget-dark stock-widget--analysis">
+              <div class="tradingview-widget-container__widget"></div>
+              <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-technical-analysis.js" async>
+                {
+                  "interval": "1D",
+                  "width": "100%",
+                  "isTransparent": false,
+                  "height": "480",
+                  "symbol": "{{ symbol | escape }}",
+                  "showIntervalTabs": true,
+                  "displayMode": "single",
+                  "colorTheme": "dark",
+                  "locale": "{{ stocks.locale | default: site.lang | default: 'en' }}"
+                }
+              </script>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  (function () {
+    var tabs = document.querySelector('[data-analysis-tabs="{{ widget_id }}"]');
+    var panels = document.querySelectorAll('[data-analysis-panel="{{ widget_id }}"]');
+
+    if (!tabs || panels.length === 0) {
+      return;
+    }
+
+    var buttons = tabs.querySelectorAll('[data-symbol]');
+
+    function setActiveSymbol(symbol) {
+      buttons.forEach(function (button) {
+        button.classList.toggle('is-active', button.getAttribute('data-symbol') === symbol);
+      });
+
+      panels.forEach(function (panel) {
+        panel.classList.toggle('is-active', panel.getAttribute('data-symbol') === symbol);
+      });
+    }
+
+    buttons.forEach(function (button) {
+      button.addEventListener('click', function () {
+        setActiveSymbol(button.getAttribute('data-symbol'));
+      });
+    });
+  })();
+</script>

--- a/assets/img/cv-icon.svg
+++ b/assets/img/cv-icon.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="CV">
-  <rect x="14" y="8" width="36" height="48" rx="4" fill="none" stroke="#555555" stroke-width="4"/>
-  <path d="M22 22h20M22 32h20M22 42h12" fill="none" stroke="#555555" stroke-width="4" stroke-linecap="round"/>
-</svg>

--- a/cv.md
+++ b/cv.md
@@ -31,6 +31,13 @@ _styles: >
     font-size: 1.12rem;
     letter-spacing: 0;
   }
+  .cv #publications + .card .card-title {
+    font-size: 0;
+  }
+  .cv #publications + .card .card-title::after {
+    content: 'Publications & Patent';
+    font-size: 1.12rem;
+  }
   .cv .list-group-item {
     border-color: var(--global-divider-color);
     padding: 0.95rem 0;


### PR DESCRIPTION
## Summary
- Replace the homepage capability cards with a quieter evidence-list layout
- Restore the previous Market Insights portfolio page at /portfolio/ without reintroducing _includes ownership
- Remove the contact note and RSS social output, and render CV as text instead of an SVG icon
- Restore CV publication entries to the al_folio_cv-supported Publications schema and display the section as Publications & Patent

## Checks
- python YAML/data assertion
- npx prettier --check _pages/about.md _pages/portfolio.md cv.md _data/cv.yml _data/socials.yml _config.yml
- npm run lint:style-contract
- git diff --check