### PR TITLE
Restore rich repository cards

### DIFF
--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -7,72 +7,135 @@ description: Selected open-source repositories and code projects.
 nav: true
 nav_order: 3
 _styles: >
+  .repo-page-intro {
+    max-width: 44rem;
+    margin-bottom: 1.75rem;
+    color: var(--global-text-color);
+    opacity: 0.78;
+  }
   .repo-section {
-    margin-top: 1.5rem;
+    margin: 2rem 0 2.5rem;
+  }
+  .repo-section__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.85rem;
+    border-bottom: 1px solid var(--global-divider-color);
+    padding-bottom: 0.55rem;
+  }
+  .repo-section__header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+  }
+  .repo-section__header span {
+    color: var(--global-text-color);
+    opacity: 0.62;
+    font-size: 0.9rem;
+    white-space: nowrap;
+  }
+  .repo-profile-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  .repo-profile-card,
+  .repo-trophy-card {
+    border: 1px solid var(--global-divider-color);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--global-bg-color);
+  }
+  html[data-theme='dark'] .repo-profile-card,
+  html[data-theme='dark'] .repo-trophy-card,
+  html[data-theme='dark'] .repo-card {
+    background: var(--global-card-bg-color);
+  }
+  .repo-profile-card__media,
+  .repo-trophy-card__media {
+    display: block;
+    padding: 0.6rem;
+  }
+  .repo-profile-card img,
+  .repo-trophy-card img,
+  .repo-card__stats img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 6px;
+  }
+  .repo-profile-card__fallback {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 0.9rem 1rem;
+    border-top: 1px solid var(--global-divider-color);
+  }
+  .repo-profile-card__avatar {
+    width: 2.8rem;
+    height: 2.8rem;
+    border-radius: 8px;
+    border: 1px solid var(--global-divider-color);
+  }
+  .repo-profile-card__fallback h3,
+  .repo-card h3 {
+    margin: 0;
+    font-size: 1rem;
+  }
+  .repo-profile-card__fallback p,
+  .repo-card p {
+    margin: 0.15rem 0 0;
+    color: var(--global-text-color);
+    opacity: 0.68;
+    font-size: 0.9rem;
   }
   .repo-grid {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 0.9rem;
-    margin: 1rem 0 2rem;
+    gap: 1rem;
   }
   @media (min-width: 768px) {
     .repo-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
-  .repo-profile,
   .repo-card {
+    overflow: hidden;
     border: 1px solid var(--global-divider-color);
     border-radius: 8px;
     background: var(--global-bg-color);
-    padding: 1rem;
     transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
   }
-  .repo-profile:hover,
   .repo-card:hover {
     border-color: var(--global-theme-color);
     transform: translateY(-2px);
     box-shadow: 0 10px 22px rgba(0, 0, 0, 0.06);
   }
-  html[data-theme='dark'] .repo-profile,
-  html[data-theme='dark'] .repo-card {
-    background: var(--global-card-bg-color);
+  .repo-card__stats {
+    display: block;
+    padding: 0.6rem 0.6rem 0;
+    min-height: 8rem;
+    background: linear-gradient(180deg, rgba(127, 127, 127, 0.06), transparent);
   }
-  .repo-profile {
+  .repo-card__body {
+    padding: 0.85rem 1rem 1rem;
+  }
+  .repo-card__title-row {
     display: flex;
-    align-items: center;
-    gap: 0.9rem;
-  }
-  .repo-profile img {
-    width: 4rem;
-    height: 4rem;
-    border-radius: 8px;
-    border: 1px solid var(--global-divider-color);
-  }
-  .repo-profile h3,
-  .repo-card h3 {
-    margin: 0;
-    font-size: 1.05rem;
-  }
-  .repo-profile p,
-  .repo-card p {
-    margin: 0.25rem 0 0;
-    color: var(--global-text-color);
-    opacity: 0.72;
-    font-size: 0.92rem;
-  }
-  .repo-card__top {
-    display: flex;
-    justify-content: space-between;
     align-items: flex-start;
+    justify-content: space-between;
     gap: 0.75rem;
   }
-  .repo-card__meta {
+  .repo-card__owner {
+    color: var(--global-text-color);
+    opacity: 0.66;
+  }
+  .repo-card__chips {
     display: flex;
     flex-wrap: wrap;
     gap: 0.45rem;
-    margin-top: 0.85rem;
+    margin-top: 0.75rem;
   }
   .repo-chip {
     display: inline-flex;
@@ -85,10 +148,6 @@ _styles: >
     color: var(--global-text-color);
     opacity: 0.78;
   }
-  .repo-card__link {
-    color: var(--global-theme-color);
-    white-space: nowrap;
-  }
   .repo-card__cta {
     display: inline-flex;
     align-items: center;
@@ -98,69 +157,142 @@ _styles: >
     font-weight: 600;
     text-decoration: none;
   }
-  .repo-card__stats {
-    display: block;
-    width: 100%;
-    max-width: 100%;
-    height: auto;
-    margin-top: 0.85rem;
-    border-radius: 6px;
+  .repo-card__cta:hover {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+  html[data-theme='dark'] .repo-light,
+  html:not([data-theme='dark']) .repo-dark {
+    display: none !important;
+  }
+  .repo-image-fallback {
+    min-height: 0;
   }
 ---
 
+<p class="repo-page-intro">A compact view of selected GitHub work. External GitHub stats cards are used as the primary presentation, with local links and metadata kept visible when those services are slow or unavailable.</p>
+
 {% if site.data.repositories.github_users %}
 
-## GitHub users
+<section class="repo-section" aria-labelledby="github-profile">
+  <div class="repo-section__header">
+    <h2 id="github-profile">GitHub profile</h2>
+    <span>{{ site.data.repositories.github_users | size }} profile</span>
+  </div>
 
-<div class="repo-grid repo-section">
-  {% for user in site.data.repositories.github_users %}
-    <a class="repo-profile" href="https://github.com/{{ user }}" target="_blank" rel="noopener noreferrer">
-      <img src="https://github.com/{{ user }}.png?size=160" alt="{{ user }} GitHub avatar" loading="lazy">
-      <span>
-        <h3><i class="fa-brands fa-github"></i> {{ user }}</h3>
-        <p>GitHub profile</p>
-      </span>
-    </a>
-  {% endfor %}
-</div>
+  <div class="repo-profile-grid">
+    {% for user in site.data.repositories.github_users %}
+      <article class="repo-profile-card">
+        <a class="repo-profile-card__media" href="https://github.com/{{ user }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ user }} on GitHub">
+          <img
+            class="repo-light"
+            src="{{ site.external_services.github_readme_stats_url }}/api/?username={{ user }}&theme={{ site.repo_theme_light }}&show_icons=true"
+            alt="{{ user }} GitHub profile stats"
+            loading="lazy"
+            onerror="this.style.display='none'"
+          >
+          <img
+            class="repo-dark"
+            src="{{ site.external_services.github_readme_stats_url }}/api/?username={{ user }}&theme={{ site.repo_theme_dark }}&show_icons=true"
+            alt="{{ user }} GitHub profile stats"
+            loading="lazy"
+            onerror="this.style.display='none'"
+          >
+        </a>
+        <a class="repo-profile-card__fallback" href="https://github.com/{{ user }}" target="_blank" rel="noopener noreferrer">
+          <img class="repo-profile-card__avatar" src="https://github.com/{{ user }}.png?size=120" alt="{{ user }} avatar" loading="lazy">
+          <span>
+            <h3><i class="fa-brands fa-github"></i> {{ user }}</h3>
+            <p>Open GitHub profile</p>
+          </span>
+        </a>
+      </article>
+    {% endfor %}
+  </div>
+
+{% if site.repo_trophies.enabled %}
+{% for user in site.data.repositories.github_users %}
+
+<article class="repo-trophy-card repo-section">
+<a class="repo-trophy-card__media" href="https://github.com/ryo-ma/github-profile-trophy" target="_blank" rel="noopener noreferrer" aria-label="Open GitHub profile trophies">
+<img
+            class="repo-light"
+            src="{{ site.external_services.github_profile_trophy_url }}/?username={{ user }}&theme={{ site.repo_trophies.theme_light }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=6"
+            alt="{{ user }} GitHub trophies"
+            loading="lazy"
+            onerror="this.style.display='none'"
+          >
+<img
+            class="repo-dark"
+            src="{{ site.external_services.github_profile_trophy_url }}/?username={{ user }}&theme={{ site.repo_trophies.theme_dark }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=6"
+            alt="{{ user }} GitHub trophies"
+            loading="lazy"
+            onerror="this.style.display='none'"
+          >
+</a>
+</article>
+{% endfor %}
+{% endif %}
+
+</section>
 
 {% endif %}
 
 {% if site.data.repositories.github_repos %}
 
-## GitHub Repositories
+<section class="repo-section" aria-labelledby="github-repositories">
+  <div class="repo-section__header">
+    <h2 id="github-repositories">Selected repositories</h2>
+    <span>{{ site.data.repositories.github_repos | size }} repos</span>
+  </div>
 
-<div class="repo-grid repo-section">
-  {% for repo in site.data.repositories.github_repos %}
-    {% assign repo_parts = repo | split: "/" %}
-    {% assign owner = repo_parts[0] %}
-    {% assign name = repo_parts[1] %}
-    <article class="repo-card">
-      <div class="repo-card__top">
-        <div>
-          <h3>{{ name }}</h3>
-          <p>{{ owner }}</p>
-        </div>
-        <a class="repo-card__link" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ repo }} on GitHub">
-          <i class="fa-brands fa-github"></i>
+  <div class="repo-grid">
+    {% for repo in site.data.repositories.github_repos %}
+      {% assign repo_parts = repo | split: "/" %}
+      {% assign owner = repo_parts[0] %}
+      {% assign name = repo_parts[1] %}
+      {% assign show_owner = true %}
+      {% if site.data.repositories.github_users contains owner %}
+        {% assign show_owner = false %}
+      {% endif %}
+      <article class="repo-card">
+        <a class="repo-card__stats" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ repo }} on GitHub">
+          <img
+            class="repo-light"
+            src="{{ site.external_services.github_readme_stats_url }}/api/pin/?username={{ owner }}&repo={{ name }}&theme={{ site.repo_theme_light }}&show_owner={{ show_owner }}&description_lines_count={{ site.data.repositories.repo_description_lines_max | default: 2 }}"
+            alt="{{ repo }} repository stats"
+            loading="lazy"
+            onerror="this.style.display='none'"
+          >
+          <img
+            class="repo-dark"
+            src="{{ site.external_services.github_readme_stats_url }}/api/pin/?username={{ owner }}&repo={{ name }}&theme={{ site.repo_theme_dark }}&show_owner={{ show_owner }}&description_lines_count={{ site.data.repositories.repo_description_lines_max | default: 2 }}"
+            alt="{{ repo }} repository stats"
+            loading="lazy"
+            onerror="this.style.display='none'"
+          >
         </a>
-      </div>
-      <div class="repo-card__meta">
-        <span class="repo-chip"><i class="fa-solid fa-code-branch"></i> Repository</span>
-        <span class="repo-chip">{{ owner }}/{{ name }}</span>
-      </div>
-      <a class="repo-card__cta" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">View repository <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
-      <a href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">
-        <img
-          class="repo-card__stats"
-          src="{{ site.external_services.github_readme_stats_url }}/api/pin/?username={{ owner }}&repo={{ name }}&theme=transparent&show_owner=true"
-          alt="{{ repo }} repository stats"
-          loading="lazy"
-          onerror="this.style.display='none'"
-        >
-      </a>
-    </article>
-  {% endfor %}
-</div>
+        <div class="repo-card__body">
+          <div class="repo-card__title-row">
+            <div>
+              <h3>{{ name }}</h3>
+              <p><span class="repo-card__owner">{{ owner }}</span></p>
+            </div>
+            <a class="repo-card__cta" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer" aria-label="Open {{ repo }} on GitHub">
+              <i class="fa-brands fa-github"></i>
+            </a>
+          </div>
+          <div class="repo-card__chips">
+            <span class="repo-chip"><i class="fa-solid fa-code-branch"></i> Repository</span>
+            <span class="repo-chip">{{ owner }}/{{ name }}</span>
+          </div>
+          <a class="repo-card__cta" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">
+            View repository <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</section>
 
 {% endif %}


### PR DESCRIPTION
## Summary
- Rework the Repositories page so GitHub stats cards are again the primary visual treatment
- Add profile stats and trophy sections using configured external services
- Keep local profile/repository links and metadata visible as reliable fallback content
- Preserve the thin starter architecture: no local _includes/_layouts/_sass ownership

## Checks
- npx prettier --check _pages/repositories.md
- npm run lint:style-contract
- git diff --check