### PR TITLE
Add reliable repository metadata

### DIFF
--- a/_data/repositories.yml
+++ b/_data/repositories.yml
@@ -8,5 +8,47 @@ github_repos:
   - liuh886/http-to-obsidian-cli-gateway
   - PleasePrompto/ductor
   - liuh886/the_ice_block_expedition_1959
-  - liuh886/open_phrasebank
+  - liuh886/open-phrasebank
   - liuh886/GEO4300_2023
+
+repo_metadata:
+  liuh886/4d-seismic-hub:
+    description: Best-practice 4D seismic exploration knowledge base with an AI-agent website interface.
+    language: Python
+    stars: 2
+    forks: 0
+  liuh886/ccus-policy-hub:
+    description: Global CCUS policy hub for tracking policy, regulation, and energy-transition context.
+    language: JavaScript
+    stars: 3
+    forks: 1
+  liuh886/GhostCam:
+    description: Ultra-light Windows virtual camera for real-time background replacement, blur, and solid-color backgrounds.
+    language: C++
+    stars: 1
+    forks: 0
+  liuh886/http-to-obsidian-cli-gateway:
+    description: Lightweight HTTP proxy gateway that lets sandboxed AI agents reach a host Obsidian CLI safely.
+    language: JavaScript
+    stars: 1
+    forks: 0
+  PleasePrompto/ductor:
+    description: Telegram control layer for Claude Code, Codex CLI, and Gemini CLI with streaming, memory, cron, webhooks, and Docker sandboxing.
+    language: Python
+    stars: 390
+    forks: 68
+  liuh886/the_ice_block_expedition_1959:
+    description: Energy-balance and heat-equation simulation of the 1959 ice block expedition.
+    language: Jupyter Notebook
+    stars: 3
+    forks: 0
+  liuh886/open-phrasebank:
+    description: Custom phrasebank generation from selected texts and corpora.
+    language: Python
+    stars: 12
+    forks: 0
+  liuh886/GEO4300_2023:
+    description: Exercise template for GEO4300 Geophysical Data Science.
+    language: Jupyter Notebook
+    stars: 0
+    forks: 0

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -145,6 +145,20 @@ _styles: >
     margin: 0;
     line-height: 1.55;
   }
+  .repo-card__metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+    margin-top: 0.8rem;
+    color: var(--global-text-color);
+    opacity: 0.72;
+    font-size: 0.85rem;
+  }
+  .repo-card__metrics span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.32rem;
+  }
   .repo-chip {
     display: inline-flex;
     align-items: center;
@@ -256,6 +270,7 @@ _styles: >
       {% assign repo_parts = repo | split: "/" %}
       {% assign owner = repo_parts[0] %}
       {% assign name = repo_parts[1] %}
+      {% assign meta = site.data.repositories.repo_metadata[repo] %}
       {% assign show_owner = true %}
       {% if site.data.repositories.github_users contains owner %}
         {% assign show_owner = false %}
@@ -289,10 +304,27 @@ _styles: >
           </div>
           <div class="repo-card__chips">
             <span class="repo-chip"><i class="fa-solid fa-code-branch"></i> Repository</span>
+            {% if meta.language %}
+              <span class="repo-chip">{{ meta.language }}</span>
+            {% endif %}
             <span class="repo-chip">{{ owner }}/{{ name }}</span>
           </div>
           <div class="repo-card__summary">
-            <p>Selected source code and project artifacts from {{ owner }}.</p>
+            {% if meta.description %}
+              <p>{{ meta.description }}</p>
+            {% else %}
+              <p>Selected source code and project artifacts from {{ owner }}.</p>
+            {% endif %}
+            {% if meta.stars or meta.forks %}
+              <div class="repo-card__metrics" aria-label="{{ repo }} GitHub metrics">
+                {% if meta.stars != nil %}
+                  <span><i class="fa-regular fa-star"></i> {{ meta.stars }}</span>
+                {% endif %}
+                {% if meta.forks != nil %}
+                  <span><i class="fa-solid fa-code-fork"></i> {{ meta.forks }}</span>
+                {% endif %}
+              </div>
+            {% endif %}
           </div>
           <a class="repo-card__cta" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">
             View repository <i class="fa-solid fa-arrow-up-right-from-square"></i>


### PR DESCRIPTION
## Summary
- Add local repository descriptions, language, stars, and forks for the Repositories page
- Correct the open-phrasebank repository slug
- Render local metadata in repository cards so the page remains rich even when external stats images are unavailable

## Checks
- python repository data assertion
- npx prettier --check _data/repositories.yml _pages/repositories.md
- npm run lint:style-contract
- git diff --check