### PR TITLE
Move homepage chat CTA under socials

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,15 @@ first_name: Zhihao
 middle_name:
 last_name: LIU
 tab_title: "Zhihao LIU | Climate & Energy Data Scientist" # preserves the previous browser-tab title customization
-contact_note:
+contact_note: >
+  <div class="home-social-cta" aria-label="Primary contact">
+    <a class="home-social-cta__primary" href="https://calendar.app.google/UQ267iEs4MTAGFSd7" target="_blank" rel="noopener noreferrer">Book a chat</a>
+    <div class="home-social-cta__secondary">
+      <a href="/portfolio/">Market Insights</a>
+      <span>/</span>
+      <a href="/cv/">CV</a>
+    </div>
+  </div>
 description: >
   Climate & energy data scientist building reproducible ML workflows and decision tools from climate and geospatial data.
 footer_text: >

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -37,7 +37,7 @@ _styles: >
     flex-wrap: wrap;
     align-items: center;
     gap: 0.45rem;
-    margin: 1.15rem 0 2.2rem;
+    margin: 1.15rem 0 2rem;
     color: var(--global-text-color-light);
     font-size: 0.95rem;
   }
@@ -57,7 +57,7 @@ _styles: >
     display: grid;
     grid-template-columns: 1fr;
     gap: 0;
-    margin: 1.9rem 0 2.85rem;
+    margin: 1.75rem 0 2.65rem;
     max-width: 48rem;
     border-top: 1px solid var(--global-divider-color);
   }
@@ -75,6 +75,16 @@ _styles: >
     font-weight: 700;
     color: var(--global-text-color);
     text-transform: uppercase;
+  }
+  .home-focus__label::before {
+    content: '';
+    display: inline-block;
+    width: 1.35rem;
+    height: 1px;
+    margin-right: 0.55rem;
+    vertical-align: middle;
+    background: var(--global-theme-color);
+    opacity: 0.7;
   }
   .home-focus__item p {
     margin-bottom: 0;
@@ -105,13 +115,69 @@ _styles: >
   .contact-icons a[title='Rss icon'] {
     display: none !important;
   }
+  .social {
+    margin-top: 2.25rem;
+  }
   .contact-note {
-    display: none;
+    display: block;
+    margin-top: 0.75rem;
+  }
+  .home-social-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.65rem;
+    margin-top: 1rem;
+  }
+  .home-social-cta__primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.35rem;
+    padding: 0.54rem 1rem;
+    border: 1px solid var(--global-theme-color);
+    border-radius: 8px;
+    color: var(--global-theme-color);
+    font-weight: 650;
+    text-decoration: none;
+    line-height: 1;
+    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  }
+  .home-social-cta__primary:hover {
+    color: var(--global-bg-color);
+    background: var(--global-theme-color);
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+  .home-social-cta__secondary {
+    display: inline-flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.45rem;
+    color: var(--global-text-color-light);
+    font-size: 0.9rem;
+  }
+  .home-social-cta__secondary a {
+    color: var(--global-text-color);
+    opacity: 0.78;
+    text-decoration: none;
+  }
+  .home-social-cta__secondary a:hover {
+    color: var(--global-theme-color);
+    opacity: 1;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+  .home-social-cta__secondary span {
+    opacity: 0.42;
   }
   @media (max-width: 575px) {
     .home-focus__item {
       grid-template-columns: 1fr;
       gap: 0.25rem;
+    }
+    .home-social-cta__primary {
+      width: min(100%, 16rem);
     }
   }
 ---
@@ -122,8 +188,6 @@ _styles: >
 </div>
 
 <div class="home-links" aria-label="Selected links">
-  <a href="https://calendar.app.google/UQ267iEs4MTAGFSd7" target="_blank" rel="noopener noreferrer">Book a chat</a>
-  <span>/</span>
   <a href="{{ '/portfolio/' | relative_url }}">Market Insights</a>
   <span>/</span>
   <a href="{{ '/cv/' | relative_url }}">CV</a>


### PR DESCRIPTION
## Summary
- Move Book a chat out of the homepage intro links and into the social/contact area beneath the icons
- Keep Market Insights and CV as quieter secondary links
- Add restrained visual hierarchy to the homepage focus labels and CTA treatment

## Checks
- python homepage CTA assertion
- npx prettier --check _pages/about.md _config.yml
- npm run lint:style-contract
- git diff --check