### PR TITLE
Polish homepage intro and CTA styling

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -182,6 +182,184 @@ _styles: >
   }
 ---
 
+<style id="home-page-polish">
+  .home-intro {
+    max-width: 42rem;
+  }
+
+  .home-links {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem;
+    margin: 1.15rem 0 2rem;
+    color: var(--global-text-color-light);
+    font-size: 0.95rem;
+  }
+
+  .home-links a {
+    color: var(--global-theme-color);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .home-links a:hover {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+
+  .home-links span {
+    opacity: 0.45;
+  }
+
+  .home-focus {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+    margin: 1.75rem 0 2.65rem;
+    max-width: 48rem;
+    border-top: 1px solid var(--global-divider-color);
+  }
+
+  .home-focus__item {
+    display: grid;
+    grid-template-columns: minmax(7.5rem, 0.34fr) 1fr;
+    gap: 1rem;
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--global-divider-color);
+  }
+
+  .home-focus__label {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    font-weight: 700;
+    color: var(--global-text-color);
+    text-transform: uppercase;
+  }
+
+  .home-focus__label::before {
+    content: "";
+    display: inline-block;
+    width: 1.35rem;
+    height: 1px;
+    margin-right: 0.55rem;
+    vertical-align: middle;
+    background: var(--global-theme-color);
+    opacity: 0.7;
+  }
+
+  .home-focus__item p {
+    margin-bottom: 0;
+    font-size: 0.95rem;
+    line-height: 1.62;
+    color: var(--global-text-color);
+  }
+
+  .home-focus__item p a {
+    color: var(--global-theme-color);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .home-focus__item p a:hover {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+
+  .contact-icons .cv-social-text::before {
+    content: "CV";
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25em;
+    font-size: 0.82em;
+    font-weight: 700;
+    letter-spacing: 0;
+    line-height: 1;
+  }
+
+  .contact-icons a[title="Rss icon"] {
+    display: none !important;
+  }
+
+  .social {
+    margin-top: 2.25rem;
+  }
+
+  .contact-note {
+    display: block;
+    margin-top: 0.75rem;
+  }
+
+  .home-social-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.65rem;
+    margin-top: 1rem;
+  }
+
+  .home-social-cta__primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.35rem;
+    padding: 0.54rem 1rem;
+    border: 1px solid var(--global-theme-color);
+    border-radius: 8px;
+    color: var(--global-theme-color);
+    font-weight: 650;
+    text-decoration: none;
+    line-height: 1;
+    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  }
+
+  .home-social-cta__primary:hover {
+    color: var(--global-bg-color);
+    background: var(--global-theme-color);
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+
+  .home-social-cta__secondary {
+    display: inline-flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.45rem;
+    color: var(--global-text-color-light);
+    font-size: 0.9rem;
+  }
+
+  .home-social-cta__secondary a {
+    color: var(--global-text-color);
+    opacity: 0.78;
+    text-decoration: none;
+  }
+
+  .home-social-cta__secondary a:hover {
+    color: var(--global-theme-color);
+    opacity: 1;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+
+  .home-social-cta__secondary span {
+    opacity: 0.42;
+  }
+
+  @media (max-width: 575px) {
+    .home-focus__item {
+      grid-template-columns: 1fr;
+      gap: 0.25rem;
+    }
+
+    .home-social-cta__primary {
+      width: min(100%, 16rem);
+    }
+  }
+</style>
+
 <div class="home-intro">
   <p>Throughout my career, I've worked at the intersection of climate, geospatial data, and applied machine learning.</p>
   <p>I build reusable decision tools from climate and geophysical data, with a bias toward workflows that can be reviewed, reproduced, and shipped.</p>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,7 +1,8 @@
 ---
 layout: about
-title: about
+title: About
 permalink: /
+nav_order: 0
 subtitle: Climate & Energy Data Scientist
 subtitle_extra: "Caixin ESG30 Young Scholar"
 
@@ -28,188 +29,11 @@ projects: false # includes projects
 display_categories: [work] # Projects show in about page
 social: true # rendered from _data/socials.yml
 home_cta: true
-_styles: >
-  .home-intro {
-    max-width: 42rem;
-  }
-  .home-links {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.45rem;
-    margin: 1.15rem 0 2rem;
-    color: var(--global-text-color-light);
-    font-size: 0.95rem;
-  }
-  .home-links a {
-    color: var(--global-theme-color);
-    font-weight: 600;
-    text-decoration: none;
-  }
-  .home-links a:hover {
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
-  .home-links span {
-    opacity: 0.45;
-  }
-  .home-focus {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 0;
-    margin: 1.75rem 0 2.65rem;
-    max-width: 48rem;
-    border-top: 1px solid var(--global-divider-color);
-  }
-  .home-focus__item {
-    display: grid;
-    grid-template-columns: minmax(7.5rem, 0.34fr) 1fr;
-    gap: 1rem;
-    padding: 1rem 0;
-    border-bottom: 1px solid var(--global-divider-color);
-  }
-  .home-focus__label {
-    margin: 0;
-    font-size: 0.82rem;
-    line-height: 1.5;
-    font-weight: 700;
-    color: var(--global-text-color);
-    text-transform: uppercase;
-  }
-  .home-focus__label::before {
-    content: '';
-    display: inline-block;
-    width: 1.35rem;
-    height: 1px;
-    margin-right: 0.55rem;
-    vertical-align: middle;
-    background: var(--global-theme-color);
-    opacity: 0.7;
-  }
-  .home-focus__item p {
-    margin-bottom: 0;
-    font-size: 0.95rem;
-    line-height: 1.62;
-    color: var(--global-text-color);
-  }
-  .home-focus__item p a {
-    color: var(--global-theme-color);
-    font-weight: 600;
-    text-decoration: none;
-  }
-  .home-focus__item p a:hover {
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
-  .contact-icons .cv-social-text::before {
-    content: 'CV';
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 1.25em;
-    font-size: 0.82em;
-    font-weight: 700;
-    letter-spacing: 0;
-    line-height: 1;
-  }
-  .contact-icons a[title='Rss icon'] {
-    display: none !important;
-  }
-  .social {
-    margin-top: 2.25rem;
-  }
-  .contact-note {
-    display: block;
-    margin-top: 0.75rem;
-  }
-  .home-social-cta {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.65rem;
-    margin-top: 1rem;
-  }
-  .home-social-cta__primary {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 2.35rem;
-    padding: 0.54rem 1rem;
-    border: 1px solid var(--global-theme-color);
-    border-radius: 8px;
-    color: var(--global-theme-color);
-    font-weight: 650;
-    text-decoration: none;
-    line-height: 1;
-    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
-  }
-  .home-social-cta__primary:hover {
-    color: var(--global-bg-color);
-    background: var(--global-theme-color);
-    text-decoration: none;
-    transform: translateY(-1px);
-  }
-  .home-social-cta__secondary {
-    display: inline-flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.45rem;
-    color: var(--global-text-color-light);
-    font-size: 0.9rem;
-  }
-  .home-social-cta__secondary a {
-    color: var(--global-text-color);
-    opacity: 0.78;
-    text-decoration: none;
-  }
-  .home-social-cta__secondary a:hover {
-    color: var(--global-theme-color);
-    opacity: 1;
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
-  .home-social-cta__secondary span {
-    opacity: 0.42;
-  }
-  @media (max-width: 575px) {
-    .home-focus__item {
-      grid-template-columns: 1fr;
-      gap: 0.25rem;
-    }
-    .home-social-cta__primary {
-      width: min(100%, 16rem);
-    }
-  }
 ---
 
 <style id="home-page-polish">
   .home-intro {
     max-width: 42rem;
-  }
-
-  .home-links {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.45rem;
-    margin: 1.15rem 0 2rem;
-    color: var(--global-text-color-light);
-    font-size: 0.95rem;
-  }
-
-  .home-links a {
-    color: var(--global-theme-color);
-    font-weight: 600;
-    text-decoration: none;
-  }
-
-  .home-links a:hover {
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
-
-  .home-links span {
-    opacity: 0.45;
   }
 
   .home-focus {
@@ -361,14 +185,8 @@ _styles: >
 </style>
 
 <div class="home-intro">
-  <p>Throughout my career, I've worked at the intersection of climate, geospatial data, and applied machine learning.</p>
-  <p>I build reusable decision tools from climate and geophysical data, with a bias toward workflows that can be reviewed, reproduced, and shipped.</p>
-</div>
-
-<div class="home-links" aria-label="Selected links">
-  <a href="{{ '/portfolio/' | relative_url }}">Market Insights</a>
-  <span>/</span>
-  <a href="{{ '/cv/' | relative_url }}">CV</a>
+  <p>I turn climate, geospatial, and energy-system data into reproducible models, monitoring workflows, and decision tools.</p>
+  <p>My recent work spans CCUS MRV, 4D seismic monitoring, remote sensing, and climate-data downscaling, with an emphasis on systems that can be audited, shipped, and used beyond a research notebook.</p>
 </div>
 
 <div class="home-focus">

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -3,7 +3,7 @@ layout: default
 permalink: /blog/
 title: Blog
 nav: true
-nav_order: 2
+nav_order: 1
 pagination:
   enabled: true
   collection: posts

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -1,11 +1,11 @@
 ---
 layout: page
 title: Projects
-nav_title: projects
+nav_title: Projects
 permalink: /projects/
 description: Selected projects in climate, geospatial ML, and decision tooling. Focused on high-stakes energy transition applications.
 nav: true
-nav_order: 1
+nav_order: 2
 year_categories: [2025-2026, 2023-2024, 2022, 2019-2020]
 horizontal: false
 ---

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -2,7 +2,7 @@
 layout: page
 permalink: /repositories/
 title: Repositories
-nav_title: repositories
+nav_title: Repositories
 description: Selected open-source repositories and code projects.
 nav: true
 nav_order: 3


### PR DESCRIPTION
## Summary
- render homepage polish CSS through the page body so the migrated layout actually applies the CTA/social styling
- remove stale top-level Market Insights / CV links and keep Book a chat plus secondary links below the social icons
- update homepage intro copy and normalize nav order/case: About, Blog, Projects, Repositories, CV

## Checks
- npx prettier --check _pages/about.md _pages/blog.md _pages/projects.md _pages/repositories.md _config.yml
- npm run lint:style-contract
- git diff --check

Note: local Jekyll serve/build could not run because Ruby/Bundler is not available in this shell; GitHub Actions should provide the full Jekyll build validation.