### PR TITLE
Fix homepage visual polish injection

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -8,6 +8,13 @@ module SiteVisualPolish
     "cv.md"
   ].freeze
 
+  TARGET_URLS = [
+    "/",
+    "/portfolio/",
+    "/repositories/",
+    "/cv/"
+  ].freeze
+
   def self.apply_cv_title(page)
     return unless page.relative_path == "cv.md"
 
@@ -18,7 +25,7 @@ module SiteVisualPolish
   end
 
   def self.apply_stylesheet(page)
-    return unless TARGET_PAGES.include?(page.relative_path)
+    return unless TARGET_PAGES.include?(page.relative_path) || TARGET_URLS.include?(page.url.to_s)
     return unless page.output.include?("</head>")
     return if page.output.include?("site-polish.css")
 


### PR DESCRIPTION
## Summary
- target site visual polish by final page URL as well as source path
- ensures the root homepage receives assets/css/site-polish.css after the centralized visual polish refactor

## Checks
- npx prettier --check assets/css/site-polish.css _pages/about.md _pages/repositories.md _pages/portfolio.md
- npm run lint:style-contract
- git diff --check