### PR TITLE
Inject visual polish for document pages

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -37,7 +37,9 @@ module SiteVisualPolish
   end
 end
 
-Jekyll::Hooks.register :pages, :post_render do |page|
-  SiteVisualPolish.apply_cv_title(page)
-  SiteVisualPolish.apply_stylesheet(page)
+[:pages, :documents].each do |hook_owner|
+  Jekyll::Hooks.register hook_owner, :post_render do |page|
+    SiteVisualPolish.apply_cv_title(page)
+    SiteVisualPolish.apply_stylesheet(page)
+  end
 end


### PR DESCRIPTION
## Summary
- register site visual polish hook for both Jekyll pages and documents
- fixes the root homepage missing assets/css/site-polish.css after the centralized polish refactor
- keeps duplicate injection guarded by the existing stylesheet check

## Checks
- npx prettier --check assets/css/site-polish.css _pages/about.md _pages/repositories.md _pages/portfolio.md
- npm run lint:style-contract
- git diff --check