### PR TITLE
Tighten mobile homepage profile image

### DIFF
--- a/assets/css/site-polish.css
+++ b/assets/css/site-polish.css
@@ -446,6 +446,23 @@ html[data-theme="dark"] .cv .card {
     margin-bottom: 1rem;
   }
 
+  .profile.float-right {
+    float: none !important;
+    width: min(100%, 17rem);
+    margin: 0 auto 1.35rem;
+  }
+
+  .profile.float-right img {
+    width: 100%;
+    aspect-ratio: 3 / 4;
+    object-fit: cover;
+  }
+
+  .profile .more-info {
+    margin-top: 0.55rem;
+    text-align: center;
+  }
+
   .home-intro p,
   .home-intro p:first-child {
     font-size: 1rem;


### PR DESCRIPTION
## Summary
- reduce the mobile homepage profile image footprint
- cancel the mobile float behavior for the profile block
- keep the fix CSS-only inside the centralized site-polish.css layer

## Checks
- npx prettier --check assets/css/site-polish.css _pages/about.md _pages/repositories.md _pages/portfolio.md
- npm run lint:style-contract
- git diff --check
- Playwright visual/DOM check against deployed pages before this fix identified the mobile profile image as the remaining first-screen issue