### PR TITLE
Polish homepage section rhythm

### DIFF
--- a/assets/css/site-polish.css
+++ b/assets/css/site-polish.css
@@ -60,12 +60,130 @@ html[data-theme="dark"] {
   text-underline-offset: 4px;
 }
 
+article > .clearfix:has(.home-intro) ~ h2 {
+  margin-top: 2.45rem;
+  margin-bottom: 1rem;
+  padding-top: 1.15rem;
+  border-top: 1px solid var(--note-border);
+  font-size: 1.42rem;
+  line-height: 1.25;
+  letter-spacing: 0;
+  text-transform: capitalize;
+}
+
+article > .clearfix:has(.home-intro) ~ .news {
+  margin-bottom: 2.2rem;
+}
+
+article > .clearfix:has(.home-intro) ~ .news table {
+  margin-bottom: 0;
+}
+
+article > .clearfix:has(.home-intro) ~ .news tr {
+  border-bottom: 1px solid color-mix(in srgb, var(--note-border) 72%, transparent);
+}
+
+article > .clearfix:has(.home-intro) ~ .news tr:last-child {
+  border-bottom: 0;
+}
+
+article > .clearfix:has(.home-intro) ~ .news td {
+  padding: 0.72rem 0;
+  line-height: 1.55;
+  vertical-align: top;
+}
+
+article > .clearfix:has(.home-intro) ~ .news td:first-child {
+  width: 10.25rem;
+  color: var(--note-muted);
+  font-size: 0.92rem;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+article > .clearfix:has(.home-intro) ~ .news .emoji {
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.18rem;
+  vertical-align: -0.12rem;
+}
+
+article > .clearfix:has(.home-intro) ~ .publications {
+  margin-top: 0.15rem;
+}
+
+article > .clearfix:has(.home-intro) ~ .publications ol.bibliography {
+  margin-bottom: 0;
+}
+
+article > .clearfix:has(.home-intro) ~ .publications ol.bibliography > li {
+  margin-bottom: 0;
+  padding: 0.2rem 0 0.55rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--note-border) 66%, transparent);
+}
+
+article > .clearfix:has(.home-intro) ~ .publications ol.bibliography > li:last-child {
+  border-bottom: 0;
+}
+
+article > .clearfix:has(.home-intro) ~ .publications .abbr {
+  display: flex;
+  align-items: flex-start;
+}
+
+article > .clearfix:has(.home-intro) ~ .publications .badge {
+  border-radius: 6px;
+  padding: 0.34rem 0.5rem;
+  font-size: 0.72rem;
+  letter-spacing: 0;
+}
+
+article > .clearfix:has(.home-intro) ~ .publications .title {
+  line-height: 1.38;
+  font-weight: 650;
+}
+
+article > .clearfix:has(.home-intro) ~ .publications .author,
+article > .clearfix:has(.home-intro) ~ .publications .periodical {
+  line-height: 1.5;
+}
+
+article > .clearfix:has(.home-intro) ~ .publications .links .btn {
+  min-height: 1.8rem;
+  padding: 0.22rem 0.55rem;
+  border-radius: 6px;
+  line-height: 1.1;
+}
+
 .contact-icons a[title="Rss icon"] {
   display: none !important;
 }
 
 .social {
   margin-top: 2rem;
+}
+
+.social .contact-icons {
+  display: flex;
+  justify-content: center;
+  gap: 0.85rem;
+  min-height: auto;
+}
+
+.social .contact-icons a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin: 0;
+}
+
+.social .contact-icons i,
+.social .contact-icons svg {
+  width: 1.55rem;
+  height: 1.55rem;
+  font-size: 1.55rem;
 }
 
 .contact-note {
@@ -467,6 +585,45 @@ html[data-theme="dark"] .cv .card {
   .home-intro p:first-child {
     font-size: 1rem;
     line-height: 1.7;
+  }
+
+  article > .clearfix:has(.home-intro) ~ h2 {
+    margin-top: 2rem;
+    font-size: 1.24rem;
+  }
+
+  article > .clearfix:has(.home-intro) ~ .news table,
+  article > .clearfix:has(.home-intro) ~ .news tbody,
+  article > .clearfix:has(.home-intro) ~ .news tr {
+    display: block;
+    width: 100%;
+  }
+
+  article > .clearfix:has(.home-intro) ~ .news tr {
+    padding: 0.72rem 0;
+  }
+
+  article > .clearfix:has(.home-intro) ~ .news td {
+    display: block;
+    width: 100%;
+    padding: 0;
+  }
+
+  article > .clearfix:has(.home-intro) ~ .news td:first-child {
+    width: 100%;
+    padding-bottom: 0.12rem;
+  }
+
+  article > .clearfix:has(.home-intro) ~ .publications ol.bibliography > li {
+    padding-bottom: 0.85rem;
+  }
+
+  article > .clearfix:has(.home-intro) ~ .publications .abbr {
+    margin-bottom: 0.45rem;
+  }
+
+  .social .contact-icons {
+    gap: 0.65rem;
   }
 
   .home-social-cta__primary {


### PR DESCRIPTION
## Summary
- refine homepage News and Selected Publications spacing, separators, and typography
- reduce oversized homepage social icons while keeping Book a chat below them
- improve mobile news layout so dates and copy stack cleanly

## Verification
- npx prettier --check assets/css/site-polish.css
- npm run lint:style-contract
- git diff --check
- Playwright preview with local CSS injected into https://zhihaol.eu.org/ at desktop and mobile widths