### PR TITLE
Preserve CV PDF polish through PurgeCSS

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -22,6 +22,11 @@ module SiteVisualPolish
       %r{(<a class="anchor" id="publications"></a>\s*<div class="card mt-3 p-3">\s*<h3 class="card-title font-weight-medium">)Publications(</h3>)},
       "\\1Publications &amp; Patent\\2"
     )
+
+    page.output = page.output.sub(
+      %r{(<a href="[^"]+\.pdf"[^>]*class=")float-right("[^>]*>\s*<i class="fa-solid fa-file-pdf"></i>\s*</a>)},
+      "\\1float-right cv-pdf-link\\2"
+    )
   end
 
   def self.apply_stylesheet(page)

--- a/assets/css/site-polish.css
+++ b/assets/css/site-polish.css
@@ -27,7 +27,7 @@ html[data-theme="dark"] {
   color: var(--note-muted);
 }
 
-.post-header .post-title a.float-right[href$=".pdf"] {
+.post-header .post-title .cv-pdf-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -40,7 +40,7 @@ html[data-theme="dark"] {
   line-height: 1 !important;
 }
 
-.post-header .post-title a.float-right[href$=".pdf"] i {
+.post-header .post-title .cv-pdf-link i {
   font-size: 1.55rem !important;
   line-height: 1 !important;
 }

--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -18,6 +18,7 @@ module.exports = {
     "font-weight-bold",
     "font-weight-medium",
     "font-weight-lighter",
+    "cv-pdf-link",
     // medium-zoom injects these at runtime, so they never appear in the static
     // HTML PurgeCSS scans; without them the zoom overlay's z-index rule is purged
     // and page chrome (scroll-progress bar, ToC) bleeds through a zoomed image.


### PR DESCRIPTION
## Summary
- add a stable cv-pdf-link class to the rendered CV PDF link
- target that class from site-polish.css instead of a complex href attribute selector
- safelist cv-pdf-link in PurgeCSS so the deployed CSS keeps the rule

## Verification
- npx prettier --check assets/css/site-polish.css purgecss.config.js
- npm run lint:style-contract
- git diff --check
- source assertions for plugin/CSS/PurgeCSS wiring

This fixes the deployed behavior where the previous PDF icon rule worked in injected preview but was removed from the production CSS by PurgeCSS.