### PR TITLE
Apply CV PDF polish after site render

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -49,6 +49,12 @@ module SiteVisualPolish
 
     page.output = page.output.sub("</head>", "#{tag}</head>")
   end
+
+  def self.apply_final_cv_polish(site)
+    (site.pages + site.documents).each do |page|
+      apply_cv_pdf_link(page)
+    end
+  end
 end
 
 [:pages, :documents].each do |hook_owner|
@@ -57,4 +63,8 @@ end
     SiteVisualPolish.apply_cv_pdf_link(page)
     SiteVisualPolish.apply_stylesheet(page)
   end
+end
+
+Jekyll::Hooks.register :site, :post_render do |site|
+  SiteVisualPolish.apply_final_cv_polish(site)
 end


### PR DESCRIPTION
## Summary
- run the CV PDF link class injection again at the site post_render stage
- keep the existing page/document hooks for publication title and stylesheet injection

## Verification
- npm run lint:style-contract
- git diff --check
- source assertions for the site post_render hook

This follows the production evidence: .cv-pdf-link is now preserved in site-polish.css, but the final CV HTML still needs the class injected after layout render.