### PR TITLE
Use stable CV PDF selector

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -15,26 +15,12 @@ module SiteVisualPolish
     "/cv/"
   ].freeze
 
-  def self.cv_page?(page)
-    page.relative_path == "cv.md" || page.url.to_s == "/cv/"
-  end
-
   def self.apply_cv_title(page)
-    return unless cv_page?(page)
+    return unless page.relative_path == "cv.md"
 
     page.output = page.output.sub(
       %r{(<a class="anchor" id="publications"></a>\s*<div class="card mt-3 p-3">\s*<h3 class="card-title font-weight-medium">)Publications(</h3>)},
       "\\1Publications &amp; Patent\\2"
-    )
-  end
-
-  def self.apply_cv_pdf_link(page)
-    return unless cv_page?(page)
-    return if page.output.include?("cv-pdf-link")
-
-    page.output = page.output.sub(
-      %r{(<h1 class="post-title">[\s\S]*?<a [^>]*href="[^"]+\.pdf"[^>]*class=")([^"]*)("[^>]*>\s*<i class="fa-solid fa-file-pdf"></i>\s*</a>)},
-      "\\1\\2 cv-pdf-link\\3"
     )
   end
 
@@ -50,21 +36,11 @@ module SiteVisualPolish
     page.output = page.output.sub("</head>", "#{tag}</head>")
   end
 
-  def self.apply_final_cv_polish(site)
-    (site.pages + site.documents).each do |page|
-      apply_cv_pdf_link(page)
-    end
-  end
 end
 
 [:pages, :documents].each do |hook_owner|
   Jekyll::Hooks.register hook_owner, :post_render do |page|
     SiteVisualPolish.apply_cv_title(page)
-    SiteVisualPolish.apply_cv_pdf_link(page)
     SiteVisualPolish.apply_stylesheet(page)
   end
-end
-
-Jekyll::Hooks.register :site, :post_render do |site|
-  SiteVisualPolish.apply_final_cv_polish(site)
 end

--- a/assets/css/site-polish.css
+++ b/assets/css/site-polish.css
@@ -27,7 +27,7 @@ html[data-theme="dark"] {
   color: var(--note-muted);
 }
 
-.post-header .post-title .cv-pdf-link {
+.post-header .post-title .float-right {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -40,7 +40,7 @@ html[data-theme="dark"] {
   line-height: 1 !important;
 }
 
-.post-header .post-title .cv-pdf-link i {
+.post-header .post-title .float-right .fa-file-pdf {
   font-size: 1.55rem !important;
   line-height: 1 !important;
 }

--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -18,7 +18,6 @@ module.exports = {
     "font-weight-bold",
     "font-weight-medium",
     "font-weight-lighter",
-    "cv-pdf-link",
     // medium-zoom injects these at runtime, so they never appear in the static
     // HTML PurgeCSS scans; without them the zoom overlay's z-index rule is purged
     // and page chrome (scroll-progress bar, ToC) bleeds through a zoomed image.


### PR DESCRIPTION
## Summary
- remove the unsuccessful cv-pdf-link injection hooks and safelist entry
- style the CV PDF title action using stable classes already present in the rendered HTML
- reduce plugin complexity instead of adding more layout-stage rewrites

## Verification
- npx prettier --check assets/css/site-polish.css purgecss.config.js
- npm run lint:style-contract
- git diff --check
- source assertions that cv-pdf-link is removed and stable selectors are present

This addresses the production evidence from PR #46: the final CV HTML never received cv-pdf-link, while the existing post-title/float-right/fa-file-pdf classes are already available for a PurgeCSS-safe selector.