### PR TITLE
Polish blog reading and project card visuals

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -3,16 +3,25 @@
 module SiteVisualPolish
   TARGET_PAGES = [
     "_pages/about.md",
+    "_pages/blog.md",
     "_pages/portfolio.md",
+    "_pages/projects.md",
     "_pages/repositories.md",
     "cv.md"
   ].freeze
 
   TARGET_URLS = [
     "/",
+    "/blog/",
     "/portfolio/",
+    "/projects/",
     "/repositories/",
     "/cv/"
+  ].freeze
+
+  TARGET_URL_PREFIXES = [
+    "/blog/",
+    "/projects/"
   ].freeze
 
   def self.apply_cv_title(page)
@@ -24,8 +33,16 @@ module SiteVisualPolish
     )
   end
 
+  def self.target_page?(page)
+    url = page.url.to_s
+
+    TARGET_PAGES.include?(page.relative_path) ||
+      TARGET_URLS.include?(url) ||
+      TARGET_URL_PREFIXES.any? { |prefix| url.start_with?(prefix) }
+  end
+
   def self.apply_stylesheet(page)
-    return unless TARGET_PAGES.include?(page.relative_path) || TARGET_URLS.include?(page.url.to_s)
+    return unless target_page?(page)
     return unless page.output.include?("</head>")
     return if page.output.include?("site-polish.css")
 

--- a/assets/css/site-polish.css
+++ b/assets/css/site-polish.css
@@ -1,9 +1,13 @@
 :root {
   --note-radius: 8px;
-  --note-border: var(--global-divider-color);
-  --note-muted: var(--global-text-color-light);
-  --note-muted: color-mix(in srgb, var(--global-text-color) 68%, transparent);
+  --note-accent: var(--global-theme-color, #2f6fed);
+  --note-bg: var(--global-bg-color, #fff);
+  --note-border: var(--global-divider-color, rgba(0, 0, 0, 0.12));
+  --note-card-bg: var(--global-card-bg-color, #fff);
+  --note-muted: var(--global-text-color-light, #657080);
+  --note-muted: color-mix(in srgb, var(--global-text-color, #111827) 68%, transparent);
   --note-shadow: 0 12px 30px rgba(0, 0, 0, 0.055);
+  --note-text: var(--global-text-color, #111827);
 }
 
 html[data-theme="dark"] {
@@ -262,6 +266,314 @@ article > .clearfix:has(.home-intro) ~ .publications .links .btn {
   opacity: 1;
   text-decoration: underline;
   text-underline-offset: 4px;
+}
+
+.header-bar {
+  margin: 0 0 1.8rem;
+  padding: 0 0 1.25rem;
+  border-bottom: 1px solid var(--note-border);
+  text-align: left;
+}
+
+.header-bar h1 {
+  margin-bottom: 0.35rem;
+  font-size: 2.25rem;
+  line-height: 1.08;
+  letter-spacing: 0;
+}
+
+.header-bar h2 {
+  max-width: 42rem;
+  margin: 0;
+  color: var(--note-muted);
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.65;
+}
+
+.tag-category-list {
+  margin: -0.55rem 0 1.8rem;
+}
+
+.tag-category-list ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.tag-category-list li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 1px solid color-mix(in srgb, var(--note-border) 82%, transparent);
+  border-radius: 999px;
+  padding: 0.24rem 0.58rem;
+  color: var(--note-muted);
+  font-size: 0.86rem;
+  line-height: 1.2;
+}
+
+.tag-category-list p {
+  display: none;
+}
+
+.tag-category-list a,
+.post-list .post-tags a,
+.post-list .post-meta a {
+  color: var(--note-muted);
+  text-decoration: none;
+}
+
+.tag-category-list a:hover,
+.post-list .post-tags a:hover,
+.post-list .post-meta a:hover {
+  color: var(--global-theme-color);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.featured-posts.container {
+  max-width: none;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.featured-posts .card,
+.post-list > li,
+.projects .card {
+  border: 1px solid color-mix(in srgb, var(--note-border) 82%, transparent);
+  border-radius: var(--note-radius);
+  background: var(--note-bg);
+  box-shadow: none;
+}
+
+html[data-theme="dark"] .featured-posts .card,
+html[data-theme="dark"] .post-list > li,
+html[data-theme="dark"] .projects .card {
+  background: var(--note-card-bg);
+}
+
+.featured-posts .card,
+.projects .card {
+  overflow: hidden;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.featured-posts a:hover .card,
+.projects a:hover .card {
+  border-color: var(--global-theme-color);
+  transform: translateY(-2px);
+  box-shadow: var(--note-shadow);
+}
+
+.featured-posts a,
+.projects a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.featured-posts .card-body {
+  padding: 1rem;
+}
+
+.featured-posts .card-title {
+  margin-bottom: 0.45rem;
+  font-size: 1.02rem;
+  font-weight: 650;
+  line-height: 1.35;
+  text-transform: none !important;
+}
+
+.featured-posts .card-text,
+.post-list > li > p:not(.post-meta):not(.post-tags) {
+  max-width: 43rem;
+  color: var(--note-muted);
+  font-size: 0.96rem;
+  line-height: 1.62;
+}
+
+.post-list {
+  max-width: 48rem;
+  margin: 0.35rem 0 0;
+  padding: 0;
+}
+
+.post-list > li {
+  list-style: none;
+  margin-bottom: 0.9rem;
+  padding: 1.1rem 1.15rem 1.05rem;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.post-list > li:hover {
+  border-color: color-mix(in srgb, var(--global-theme-color) 70%, var(--note-border));
+  box-shadow: var(--note-shadow);
+  transform: translateY(-1px);
+}
+
+.post-list h3 {
+  margin: 0 0 0.42rem;
+  font-size: 1.18rem;
+  line-height: 1.33;
+  letter-spacing: 0;
+}
+
+.post-list .post-title {
+  color: var(--global-text-color);
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.post-list .post-title:hover {
+  color: var(--global-theme-color);
+  text-decoration: none;
+}
+
+.post-list .post-meta,
+.post-list .post-tags {
+  margin-bottom: 0.15rem;
+  color: var(--note-muted);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.post-list .post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.45rem;
+  margin-top: 0.45rem;
+}
+
+.post-list img.card-img {
+  width: 100%;
+  min-height: 8.8rem;
+  border-radius: 6px;
+}
+
+article > .post-content,
+article .post > p,
+article .post > ul,
+article .post > ol,
+article .post > blockquote,
+article .post > table,
+article .post > div:not(.header-bar):not(.tag-category-list):not(.featured-posts):not(.projects):not(.publications):not(.social) {
+  max-width: 47rem;
+}
+
+article .post > p,
+article .post-content p {
+  line-height: 1.72;
+}
+
+article .post h2,
+article .post-content h2 {
+  margin-top: 2.25rem;
+  padding-top: 0.95rem;
+  border-top: 1px solid color-mix(in srgb, var(--note-border) 72%, transparent);
+  font-size: 1.38rem;
+  line-height: 1.28;
+  letter-spacing: 0;
+}
+
+article .post h3,
+article .post-content h3 {
+  margin-top: 1.7rem;
+  font-size: 1.12rem;
+  line-height: 1.35;
+  letter-spacing: 0;
+}
+
+article .post blockquote,
+article .post-content blockquote {
+  margin: 1.25rem 0;
+  padding: 0.85rem 1rem;
+  border-left: 3px solid var(--global-theme-color);
+  border-radius: 0 var(--note-radius) var(--note-radius) 0;
+  background: color-mix(in srgb, var(--global-text-color) 3%, transparent);
+  color: var(--global-text-color);
+}
+
+article .post blockquote p:last-child,
+article .post-content blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+article .post pre,
+article .post-content pre,
+article .post figure,
+article .post-content figure {
+  border-radius: var(--note-radius);
+}
+
+article > .lead,
+article .post > .lead {
+  max-width: 45rem;
+  color: var(--note-muted);
+  font-size: 1rem;
+  line-height: 1.68;
+}
+
+.projects h2.category {
+  margin: 2.2rem 0 0.9rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--note-border);
+  color: var(--global-text-color);
+  font-size: 1.18rem;
+  font-weight: 500;
+  line-height: 1.3;
+  letter-spacing: 0;
+}
+
+.projects .row {
+  row-gap: 1.25rem;
+  margin-bottom: 0.9rem;
+}
+
+.projects .card {
+  height: 100%;
+}
+
+.projects .card figure {
+  margin: 0;
+  aspect-ratio: 16 / 10;
+  border-bottom: 1px solid color-mix(in srgb, var(--note-border) 72%, transparent);
+  background: color-mix(in srgb, var(--global-text-color) 3%, transparent);
+}
+
+.projects .card img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.projects .card-body {
+  padding: 1rem;
+}
+
+.projects .card-title {
+  margin-bottom: 0.45rem;
+  color: var(--global-text-color);
+  font-size: 0.98rem;
+  font-weight: 650;
+  line-height: 1.35;
+  letter-spacing: 0;
+}
+
+.projects .card-text {
+  color: var(--note-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 
 .repo-page-intro {
@@ -688,6 +1000,60 @@ html[data-theme="dark"] .cv .card {
 
   .repo-card__body {
     padding: 0.95rem;
+  }
+
+  .header-bar {
+    margin-bottom: 1.35rem;
+  }
+
+  .header-bar h1 {
+    font-size: 1.9rem;
+  }
+
+  .tag-category-list {
+    margin-bottom: 1.35rem;
+  }
+
+  .post-list {
+    max-width: none;
+  }
+
+  .post-list > li {
+    padding: 0.95rem;
+  }
+
+  .post-list h3 {
+    font-size: 1.06rem;
+  }
+
+  .featured-posts .row {
+    display: block;
+  }
+
+  .featured-posts .col {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  article > .post-content,
+  article .post > p,
+  article .post > ul,
+  article .post > ol,
+  article .post > blockquote,
+  article .post > table,
+  article .post > div:not(.header-bar):not(.tag-category-list):not(.featured-posts):not(.projects):not(.publications):not(.social) {
+    max-width: none;
+  }
+
+  article .post h2,
+  article .post-content h2 {
+    margin-top: 1.8rem;
+    font-size: 1.22rem;
+  }
+
+  .projects h2.category {
+    margin-top: 1.75rem;
+    font-size: 1.08rem;
   }
 
   article:has(.stock-widget) > h2,


### PR DESCRIPTION
## Summary
- extend the visual polish layer to blog indexes, posts, projects, and project detail pages
- refine blog lists, featured cards, tags, post reading rhythm, and project cards with restrained borders, spacing, and media sizing
- keep changes outside al-folio theme-owned internals and centralize them in the existing polish layer

## Verification
- npm run lint:style-contract
- npx prettier --check assets/css/site-polish.css
- git diff --check
- offline Playwright preview against _site with injected CSS for blog/projects desktop and mobile; production visual verification should follow after GitHub Pages deploy because local Ruby/Bundler is unavailable