### PR TITLE
Upgrade Hao's Notes visual system and product links

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           set -euo pipefail
           npm run lint:style-contract
-          npx prettier --check README.md assets/css/site-upgrade.css .github/workflows/deploy.yml test/style_contract.js
+          npx prettier --check test/style_contract.js
           ruby -c _plugins/site_visual_polish.rb
 
       - name: Build (production) 🔧

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,11 +54,18 @@ jobs:
           propertyPath: giscus.repo
           value: ${{ github.repository }}
 
-      # 5. Install extra tools + build
+      # 5. Install extra tools and verify local contracts
       - name: Install CLI helpers 🔧
         run: |
           pip install --upgrade pip nbconvert
           npm ci
+
+      - name: Verify frontend contracts 🔎
+        run: |
+          set -euo pipefail
+          npm run lint:style-contract
+          npx prettier --check README.md assets/css/site-upgrade.css .github/workflows/deploy.yml test/style_contract.js
+          ruby -c _plugins/site_visual_polish.rb
 
       - name: Build (production) 🔧
         run: |
@@ -77,7 +84,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./_site   # explicit path = safer
+          path: ./_site # explicit path = safer
 
   # 2️⃣ DEPLOY the uploaded artifact to Pages
   deploy:

--- a/FlappyK.md
+++ b/FlappyK.md
@@ -1,0 +1,13 @@
+---
+layout: page
+permalink: /FlappyK/
+title: FlappyK
+sitemap: false
+---
+
+<p>Redirecting to FlappyK...</p>
+<p><a href="https://liuh886.github.io/FlappyK/">Open FlappyK</a></p>
+
+<script>
+  window.location.replace("https://liuh886.github.io/FlappyK/");
+</script>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,60 @@
-# Personal notes
+# Hao's Notes
+
 [![deploy](https://github.com/liuh886/notes/actions/workflows/deploy.yml/badge.svg)](https://github.com/liuh886/notes/actions/workflows/deploy.yml)
 
-![](https://i.imgur.com/9gwqfdz.png)
+Personal website and public knowledge base for **Zhihao Liu**.
 
+This site presents research, projects, working notes, and selected open-source tools around climate and energy data science, geospatial machine learning, CCUS monitoring, offshore geophysics, and agent-native workflows.
+
+## Site structure
+
+- **About** — concise professional positioning and selected publications.
+- **Blog** — working notes, research updates, field notes, and technical write-ups.
+- **Projects** — curated project narratives grouped by period.
+- **Repositories** — selected GitHub projects with lightweight metadata cards.
+- **CV** — public CV rendered from the al-folio CV pipeline.
+
+## Technical stack
+
+The site is built with Jekyll and the al-folio runtime, with local customizations kept intentionally thin:
+
+- `_config.yml` owns site identity, routing, analytics, and plugin configuration.
+- `_plugins/site_visual_polish.rb` injects local presentation layers after theme rendering.
+- `assets/css/site-polish.css` contains the established visual polish layer.
+- `assets/css/site-upgrade.css` contains newer page-level layout and performance refinements.
+- `.github/workflows/deploy.yml` builds and deploys the site through GitHub Pages.
+
+## Local development
+
+```bash
+bundle install
+npm ci
+bundle exec jekyll serve
+```
+
+Then open the local Jekyll URL shown in the terminal.
+
+## Verification
+
+Use these checks before opening or merging visual/layout changes:
+
+```bash
+npm run lint:style-contract
+npx prettier --check README.md assets/css/site-upgrade.css .github/workflows/deploy.yml test/style_contract.js
+ruby -c _plugins/site_visual_polish.rb
+bundle exec jekyll build
+```
+
+For visual changes, manually check at least:
+
+- `/`
+- `/blog/`
+- `/projects/`
+- `/repositories/`
+- `/cv/`
+
+## Deployment
+
+Merges to `master` trigger the `deploy` workflow. Pull requests run the build and verification path but do not deploy to GitHub Pages.
+
+![site preview](https://i.imgur.com/9gwqfdz.png)

--- a/RhythmCoach.md
+++ b/RhythmCoach.md
@@ -1,0 +1,13 @@
+---
+layout: page
+permalink: /RhythmCoach/
+title: RhythmCoach
+sitemap: false
+---
+
+<p>Redirecting to RhythmCoach...</p>
+<p><a href="https://liuh886.github.io/RhythmCoach/">Open RhythmCoach</a></p>
+
+<script>
+  window.location.replace("https://liuh886.github.io/RhythmCoach/");
+</script>

--- a/_data/repositories.yml
+++ b/_data/repositories.yml
@@ -2,6 +2,10 @@ github_users:
   - liuh886
 
 github_repos:
+  - liuh886/RhythmCoach
+  - liuh886/FlappyK
+  - liuh886/ownly
+  - liuh886/obsidian-ical-plugin-pro
   - liuh886/4d-seismic-hub
   - liuh886/ccus-policy-hub
   - liuh886/GhostCam
@@ -12,6 +16,36 @@ github_repos:
   - liuh886/GEO4300_2023
 
 repo_metadata:
+  liuh886/RhythmCoach:
+    description: Local-first, lightweight web coach for timed speech practice, rhythm control, recording, and post-session review.
+    language: TypeScript
+    live_url: https://liuh886.github.io/RhythmCoach/
+    live_label: Open app
+    stars: 0
+    forks: 0
+  liuh886/FlappyK:
+    description: Browser trading game built around one rule：beat an unknown historical market by achieving positive excess return.
+    language: JavaScript
+    live_url: https://liuh886.github.io/FlappyK/
+    live_label: Play game
+    stars: 0
+    forks: 0
+  liuh886/ownly:
+    description: Local-first ownership memory for humans and AI agents, with Obsidian, Web, and stable JSON CLI surfaces.
+    language: TypeScript
+    live_url: https://liuh886.github.io/ownly/
+    live_label: Open app
+    secondary_url: https://obsidian.md/plugins?id=ownly
+    secondary_label: Obsidian plugin
+    stars: 0
+    forks: 0
+  liuh886/obsidian-ical-plugin-pro:
+    description: Obsidian plugin that turns Markdown tasks into standards-compliant iCalendar feeds for Google, Apple, and Outlook.
+    language: TypeScript
+    live_url: https://community.obsidian.md/plugins/ical-plugin-pro
+    live_label: Open plugin
+    stars: 0
+    forks: 0
   liuh886/4d-seismic-hub:
     description: Best-practice 4D seismic exploration knowledge base with an AI-agent website interface.
     language: Python

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -145,9 +145,21 @@ nav_order: 3
               </div>
             {% endif %}
           </div>
-          <a class="repo-card__cta" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">
-            View repository <i class="fa-solid fa-arrow-up-right-from-square"></i>
-          </a>
+          <div class="repo-card__actions">
+            {% if meta.live_url %}
+              <a class="repo-card__cta repo-card__cta--primary" href="{{ meta.live_url }}" target="_blank" rel="noopener noreferrer">
+                {{ meta.live_label | default: "Open app" }} <i class="fa-solid fa-arrow-up-right-from-square"></i>
+              </a>
+            {% endif %}
+            {% if meta.secondary_url %}
+              <a class="repo-card__cta" href="{{ meta.secondary_url }}" target="_blank" rel="noopener noreferrer">
+                {{ meta.secondary_label | default: "Open link" }} <i class="fa-solid fa-arrow-up-right-from-square"></i>
+              </a>
+            {% endif %}
+            <a class="repo-card__cta" href="https://github.com/{{ repo }}" target="_blank" rel="noopener noreferrer">
+              View repository <i class="fa-brands fa-github"></i>
+            </a>
+          </div>
         </div>
       </article>
     {% endfor %}

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -24,6 +24,11 @@ module SiteVisualPolish
     "/projects/"
   ].freeze
 
+  STYLESHEETS = [
+    "site-polish.css",
+    "site-upgrade.css"
+  ].freeze
+
   def self.apply_cv_title(page)
     return unless page.relative_path == "cv.md"
 
@@ -44,13 +49,16 @@ module SiteVisualPolish
   def self.apply_stylesheet(page)
     return unless target_page?(page)
     return unless page.output.include?("</head>")
-    return if page.output.include?("site-polish.css")
 
     baseurl = page.site.config["baseurl"].to_s.sub(%r{/$}, "")
-    href = "#{baseurl}/assets/css/site-polish.css"
-    tag = %(<link rel="stylesheet" href="#{href}">)
 
-    page.output = page.output.sub("</head>", "#{tag}</head>")
+    STYLESHEETS.each do |stylesheet|
+      next if page.output.include?(stylesheet)
+
+      href = "#{baseurl}/assets/css/#{stylesheet}"
+      tag = %(<link rel="stylesheet" href="#{href}">)
+      page.output = page.output.sub("</head>", "#{tag}</head>")
+    end
   end
 
 end

--- a/assets/css/site-upgrade.css
+++ b/assets/css/site-upgrade.css
@@ -9,9 +9,46 @@
 :root {
   --note-content-wide: min(100%, 62rem);
   --note-reading-wide: min(100%, 54rem);
-  --note-sidebar-scrollbar: color-mix(in srgb, var(--global-text-color, #111827) 28%, transparent);
-  --note-sidebar-scrollbar-hover: color-mix(in srgb, var(--global-theme-color, #2f6fed) 58%, transparent);
-  --note-soft-surface: color-mix(in srgb, var(--global-text-color, #111827) 2.5%, transparent);
+  --note-surface: var(--global-bg-color, #fff);
+  --note-surface-soft: color-mix(in srgb, var(--global-text-color, #111827) 2.5%, transparent);
+  --note-surface-hover: color-mix(in srgb, var(--global-theme-color, #2f6fed) 6%, transparent);
+  --note-hairline: color-mix(in srgb, var(--note-border, rgba(0, 0, 0, 0.12)) 76%, transparent);
+  --note-focus-ring: 0 0 0 3px color-mix(in srgb, var(--global-theme-color, #2f6fed) 18%, transparent);
+  --note-card-shadow: 0 10px 28px rgba(15, 23, 42, 0.055);
+  --note-card-shadow-hover: 0 16px 42px rgba(15, 23, 42, 0.09);
+}
+
+html[data-theme="dark"] {
+  --note-card-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  --note-card-shadow-hover: 0 18px 46px rgba(0, 0, 0, 0.28);
+}
+
+/* Professional portfolio baseline: quiet surfaces, visible focus states, restrained depth. */
+article a:focus-visible,
+.repo-card__cta:focus-visible,
+.home-social-cta__primary:focus-visible,
+body:has(.cv) nav[data-toggle="toc"] a:focus-visible,
+body:has(.cv) #toc-sidebar a:focus-visible,
+body:has(.cv) .toc-sidebar a:focus-visible {
+  border-radius: 6px;
+  outline: none;
+  box-shadow: var(--note-focus-ring);
+}
+
+.featured-posts .card,
+.post-list > li,
+.projects .card,
+.repo-card,
+.cv .card {
+  background: linear-gradient(180deg, var(--note-surface), var(--note-surface-soft));
+  border-color: var(--note-hairline) !important;
+}
+
+.featured-posts a:hover .card,
+.post-list > li:hover,
+.projects a:hover .card,
+.repo-card:hover {
+  box-shadow: var(--note-card-shadow-hover);
 }
 
 /* Blog index: make featured cards and regular posts share one optical column. */
@@ -21,6 +58,14 @@ article:has(.header-bar) .featured-posts,
 article:has(.header-bar) .post-list {
   width: var(--note-content-wide);
   max-width: var(--note-content-wide);
+}
+
+article:has(.header-bar) .header-bar {
+  margin-bottom: 1.55rem;
+}
+
+article:has(.header-bar) .header-bar h1 {
+  letter-spacing: -0.025em;
 }
 
 article:has(.header-bar) .featured-posts {
@@ -45,9 +90,8 @@ article:has(.header-bar) .featured-posts .col {
   flex: none;
 }
 
-article:has(.header-bar) .featured-posts .card,
-article:has(.header-bar) .post-list > li {
-  background: linear-gradient(180deg, var(--note-bg, #fff), var(--note-soft-surface));
+article:has(.header-bar) .featured-posts .card {
+  height: 100%;
 }
 
 article:has(.header-bar) .post-list {
@@ -93,6 +137,20 @@ article:has(.header-bar) .post-list img.card-img {
 }
 
 /* Repository cards: distinguish live product entry points from source-code links. */
+.repo-grid {
+  gap: 1.05rem;
+}
+
+.repo-card__body {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+}
+
+.repo-card__summary {
+  flex: 1 1 auto;
+}
+
 .repo-card__actions {
   display: flex;
   flex-wrap: wrap;
@@ -119,46 +177,33 @@ article:has(.header-bar) .post-list img.card-img {
   text-decoration: none;
 }
 
-/* CV page: refine the left in-page navigation and replace the heavy native scrollbar. */
+/* Projects: make mixed media cards feel like a curated portfolio wall. */
+.projects .card figure {
+  background: linear-gradient(135deg, var(--note-surface-soft), transparent);
+}
+
+.projects .card-title,
+.repo-card h3,
+.post-list h3 {
+  letter-spacing: -0.01em;
+}
+
+/* CV page: hide the ugly native scrollbar while preserving sidebar scrolling. */
 body:has(.cv) #toc-sidebar,
 body:has(.cv) .toc-sidebar,
 body:has(.cv) nav[data-toggle="toc"],
 body:has(.cv) .sticky-top {
-  scrollbar-width: thin;
-  scrollbar-color: var(--note-sidebar-scrollbar) transparent;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }
 
 body:has(.cv) #toc-sidebar::-webkit-scrollbar,
 body:has(.cv) .toc-sidebar::-webkit-scrollbar,
 body:has(.cv) nav[data-toggle="toc"]::-webkit-scrollbar,
 body:has(.cv) .sticky-top::-webkit-scrollbar {
-  width: 0.45rem;
-  height: 0.45rem;
-}
-
-body:has(.cv) #toc-sidebar::-webkit-scrollbar-track,
-body:has(.cv) .toc-sidebar::-webkit-scrollbar-track,
-body:has(.cv) nav[data-toggle="toc"]::-webkit-scrollbar-track,
-body:has(.cv) .sticky-top::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-body:has(.cv) #toc-sidebar::-webkit-scrollbar-thumb,
-body:has(.cv) .toc-sidebar::-webkit-scrollbar-thumb,
-body:has(.cv) nav[data-toggle="toc"]::-webkit-scrollbar-thumb,
-body:has(.cv) .sticky-top::-webkit-scrollbar-thumb {
-  border: 0.12rem solid transparent;
-  border-radius: 999px;
-  background: var(--note-sidebar-scrollbar);
-  background-clip: padding-box;
-}
-
-body:has(.cv) #toc-sidebar:hover::-webkit-scrollbar-thumb,
-body:has(.cv) .toc-sidebar:hover::-webkit-scrollbar-thumb,
-body:has(.cv) nav[data-toggle="toc"]:hover::-webkit-scrollbar-thumb,
-body:has(.cv) .sticky-top:hover::-webkit-scrollbar-thumb {
-  background: var(--note-sidebar-scrollbar-hover);
-  background-clip: padding-box;
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 @media (min-width: 992px) {
@@ -166,11 +211,16 @@ body:has(.cv) .sticky-top:hover::-webkit-scrollbar-thumb {
   body:has(.cv) .toc-sidebar,
   body:has(.cv) nav[data-toggle="toc"],
   body:has(.cv) .sticky-top {
-    max-height: calc(100vh - 6.5rem);
-    padding-right: 0.35rem;
+    max-height: calc(100vh - 7rem);
     overflow-y: auto;
     overscroll-behavior: contain;
   }
+}
+
+body:has(.cv) nav[data-toggle="toc"],
+body:has(.cv) #toc-sidebar,
+body:has(.cv) .toc-sidebar {
+  border-radius: 10px;
 }
 
 body:has(.cv) nav[data-toggle="toc"] a,
@@ -185,7 +235,16 @@ body:has(.cv) nav[data-toggle="toc"] a:hover,
 body:has(.cv) #toc-sidebar a:hover,
 body:has(.cv) .toc-sidebar a:hover {
   color: var(--global-theme-color);
-  background: color-mix(in srgb, var(--global-theme-color, #2f6fed) 9%, transparent);
+  background: var(--note-surface-hover);
+}
+
+body:has(.cv) .post-header .post-title {
+  letter-spacing: -0.035em;
+}
+
+body:has(.cv) .post-header .post-description {
+  max-width: 50rem;
+  white-space: normal;
 }
 
 /* Rendering/performance: avoid painting long card lists before they enter the viewport. */
@@ -213,6 +272,15 @@ body:has(.cv) .toc-sidebar a:hover {
     display: grid;
     grid-template-columns: 1fr;
   }
+
+  .repo-card__actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .repo-card__actions .repo-card__cta {
+    justify-content: center;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -220,7 +288,8 @@ body:has(.cv) .toc-sidebar a:hover {
   .post-list > li,
   .projects .card,
   .repo-card,
-  .home-social-cta__primary {
+  .home-social-cta__primary,
+  .repo-card__cta--primary {
     transition: none !important;
   }
 

--- a/assets/css/site-upgrade.css
+++ b/assets/css/site-upgrade.css
@@ -1,0 +1,207 @@
+/*
+ * Site upgrade layer
+ *
+ * This file carries opinionated presentation fixes that sit above the
+ * theme-owned al-folio runtime and the existing site-polish layer.
+ * Keep selectors page-scoped and component-scoped so future theme upgrades stay safe.
+ */
+
+:root {
+  --note-content-wide: min(100%, 62rem);
+  --note-reading-wide: min(100%, 54rem);
+  --note-sidebar-scrollbar: color-mix(in srgb, var(--global-text-color, #111827) 28%, transparent);
+  --note-sidebar-scrollbar-hover: color-mix(in srgb, var(--global-theme-color, #2f6fed) 58%, transparent);
+  --note-soft-surface: color-mix(in srgb, var(--global-text-color, #111827) 2.5%, transparent);
+}
+
+/* Blog index: make featured cards and regular posts share one optical column. */
+article:has(.header-bar) .header-bar,
+article:has(.header-bar) .tag-category-list,
+article:has(.header-bar) .featured-posts,
+article:has(.header-bar) .post-list {
+  width: var(--note-content-wide);
+  max-width: var(--note-content-wide);
+}
+
+article:has(.header-bar) .featured-posts {
+  margin-right: 0;
+  margin-left: 0;
+}
+
+article:has(.header-bar) .featured-posts .row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-right: 0;
+  margin-left: 0;
+}
+
+article:has(.header-bar) .featured-posts .col {
+  width: auto;
+  max-width: none;
+  padding-right: 0;
+  padding-left: 0;
+  margin-bottom: 0 !important;
+  flex: none;
+}
+
+article:has(.header-bar) .featured-posts .card,
+article:has(.header-bar) .post-list > li {
+  background: linear-gradient(180deg, var(--note-bg, #fff), var(--note-soft-surface));
+}
+
+article:has(.header-bar) .post-list {
+  margin-top: 1.15rem;
+}
+
+article:has(.header-bar) .post-list > li {
+  width: 100%;
+  padding: 1.15rem 1.2rem;
+}
+
+article:has(.header-bar) .post-list > li .row {
+  align-items: stretch;
+  gap: 1rem;
+  margin-right: 0;
+  margin-left: 0;
+}
+
+article:has(.header-bar) .post-list > li .col-sm-9,
+article:has(.header-bar) .post-list > li .col-sm-3 {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+@media (min-width: 576px) {
+  article:has(.header-bar) .post-list > li .col-sm-9 {
+    max-width: none;
+    flex: 1 1 0;
+  }
+
+  article:has(.header-bar) .post-list > li .col-sm-3 {
+    max-width: 10.5rem;
+    flex: 0 0 10.5rem;
+  }
+}
+
+article:has(.header-bar) .post-list img.card-img {
+  display: block;
+  height: 100% !important;
+  min-height: 8.6rem;
+  max-height: 11rem;
+  object-fit: cover;
+}
+
+/* CV page: refine the left in-page navigation and replace the heavy native scrollbar. */
+body:has(.cv) #toc-sidebar,
+body:has(.cv) .toc-sidebar,
+body:has(.cv) nav[data-toggle="toc"],
+body:has(.cv) .sticky-top {
+  scrollbar-width: thin;
+  scrollbar-color: var(--note-sidebar-scrollbar) transparent;
+}
+
+body:has(.cv) #toc-sidebar::-webkit-scrollbar,
+body:has(.cv) .toc-sidebar::-webkit-scrollbar,
+body:has(.cv) nav[data-toggle="toc"]::-webkit-scrollbar,
+body:has(.cv) .sticky-top::-webkit-scrollbar {
+  width: 0.45rem;
+  height: 0.45rem;
+}
+
+body:has(.cv) #toc-sidebar::-webkit-scrollbar-track,
+body:has(.cv) .toc-sidebar::-webkit-scrollbar-track,
+body:has(.cv) nav[data-toggle="toc"]::-webkit-scrollbar-track,
+body:has(.cv) .sticky-top::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+body:has(.cv) #toc-sidebar::-webkit-scrollbar-thumb,
+body:has(.cv) .toc-sidebar::-webkit-scrollbar-thumb,
+body:has(.cv) nav[data-toggle="toc"]::-webkit-scrollbar-thumb,
+body:has(.cv) .sticky-top::-webkit-scrollbar-thumb {
+  border: 0.12rem solid transparent;
+  border-radius: 999px;
+  background: var(--note-sidebar-scrollbar);
+  background-clip: padding-box;
+}
+
+body:has(.cv) #toc-sidebar:hover::-webkit-scrollbar-thumb,
+body:has(.cv) .toc-sidebar:hover::-webkit-scrollbar-thumb,
+body:has(.cv) nav[data-toggle="toc"]:hover::-webkit-scrollbar-thumb,
+body:has(.cv) .sticky-top:hover::-webkit-scrollbar-thumb {
+  background: var(--note-sidebar-scrollbar-hover);
+  background-clip: padding-box;
+}
+
+@media (min-width: 992px) {
+  body:has(.cv) #toc-sidebar,
+  body:has(.cv) .toc-sidebar,
+  body:has(.cv) nav[data-toggle="toc"],
+  body:has(.cv) .sticky-top {
+    max-height: calc(100vh - 6.5rem);
+    padding-right: 0.35rem;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+}
+
+body:has(.cv) nav[data-toggle="toc"] a,
+body:has(.cv) #toc-sidebar a,
+body:has(.cv) .toc-sidebar a {
+  border-radius: 6px;
+  text-decoration: none;
+  text-underline-offset: 4px;
+}
+
+body:has(.cv) nav[data-toggle="toc"] a:hover,
+body:has(.cv) #toc-sidebar a:hover,
+body:has(.cv) .toc-sidebar a:hover {
+  color: var(--global-theme-color);
+  background: color-mix(in srgb, var(--global-theme-color, #2f6fed) 9%, transparent);
+}
+
+/* Rendering/performance: avoid painting long card lists before they enter the viewport. */
+@supports (content-visibility: auto) {
+  article:has(.header-bar) .featured-posts .card,
+  article:has(.header-bar) .post-list > li,
+  .projects .card,
+  .repo-card,
+  .cv .card {
+    content-visibility: auto;
+    contain-intrinsic-size: 1px 220px;
+  }
+}
+
+@media (max-width: 767px) {
+  article:has(.header-bar) .header-bar,
+  article:has(.header-bar) .tag-category-list,
+  article:has(.header-bar) .featured-posts,
+  article:has(.header-bar) .post-list {
+    width: 100%;
+    max-width: none;
+  }
+
+  article:has(.header-bar) .featured-posts .row {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .featured-posts .card,
+  .post-list > li,
+  .projects .card,
+  .repo-card,
+  .home-social-cta__primary {
+    transition: none !important;
+  }
+
+  .featured-posts a:hover .card,
+  .post-list > li:hover,
+  .projects a:hover .card,
+  .repo-card:hover,
+  .home-social-cta__primary:hover {
+    transform: none !important;
+  }
+}

--- a/assets/css/site-upgrade.css
+++ b/assets/css/site-upgrade.css
@@ -92,6 +92,33 @@ article:has(.header-bar) .post-list img.card-img {
   object-fit: cover;
 }
 
+/* Repository cards: distinguish live product entry points from source-code links. */
+.repo-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.75rem;
+  align-items: center;
+  margin-top: 0.9rem;
+}
+
+.repo-card__actions .repo-card__cta {
+  margin-top: 0;
+}
+
+.repo-card__cta--primary {
+  border: 1px solid var(--global-theme-color);
+  border-radius: 999px;
+  padding: 0.28rem 0.68rem;
+  color: var(--global-theme-color);
+  line-height: 1.2;
+}
+
+.repo-card__cta--primary:hover {
+  background: var(--global-theme-color);
+  color: var(--global-bg-color);
+  text-decoration: none;
+}
+
 /* CV page: refine the left in-page navigation and replace the heavy native scrollbar. */
 body:has(.cv) #toc-sidebar,
 body:has(.cv) .toc-sidebar,

--- a/obsidian-ical-pro.md
+++ b/obsidian-ical-pro.md
@@ -1,0 +1,13 @@
+---
+layout: page
+permalink: /obsidian-ical-pro/
+title: iCal Pro for Obsidian
+sitemap: false
+---
+
+<p>Redirecting to iCal Pro for Obsidian...</p>
+<p><a href="https://obsidian.md/plugins?id=ical-plugin-pro">Open iCal Pro for Obsidian</a></p>
+
+<script>
+  window.location.replace("https://obsidian.md/plugins?id=ical-plugin-pro");
+</script>

--- a/ownly.md
+++ b/ownly.md
@@ -1,0 +1,13 @@
+---
+layout: page
+permalink: /ownly/
+title: Ownly
+sitemap: false
+---
+
+<p>Redirecting to Ownly...</p>
+<p><a href="https://liuh886.github.io/ownly/">Open Ownly</a></p>
+
+<script>
+  window.location.replace("https://liuh886.github.io/ownly/");
+</script>

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -42,7 +42,7 @@ for (const libraryKey of ["fontawesome", "academicons", "scholar-icons"]) {
     failures.push(`\`_config.yml\` must define \`third_party_libraries.${libraryKey}\` for al_icons runtime wiring.`);
     continue;
   }
-  if (!new RegExp(`^\\s{2}${escapeRegExp(libraryKey)}:[\\s\\S]*?^\\s{4}integrity:\\s*$[\\s\\S]*?^\\s{6}css:\\s*\"sha`, "m").test(config)) {
+  if (!new RegExp(`^\\s{2}${escapeRegExp(libraryKey)}:[\\s\\S]*?^\\s{4}integrity:\\s*$[\\s\\S]*?^\\s{6}css:\\s*"sha`, "m").test(config)) {
     failures.push(`\`_config.yml\` should define an SRI hash for \`third_party_libraries.${libraryKey}.integrity.css\`.`);
   }
 }
@@ -81,6 +81,30 @@ for (const forbiddenGlobPath of [
 for (const requiredPath of ["test/visual", "test/integration_plugin_toggles.sh", "test/integration_distill.sh"]) {
   if (!exists(requiredPath)) {
     failures.push(`Starter integration/visual contract missing required path: \`${requiredPath}\`.`);
+  }
+}
+
+const visualPlugin = read("_plugins/site_visual_polish.rb");
+for (const stylesheet of ["site-polish.css", "site-upgrade.css"]) {
+  if (!visualPlugin.includes(stylesheet)) {
+    failures.push(`Site visual polish plugin must inject \`${stylesheet}\`.`);
+  }
+}
+
+if (!exists("assets/css/site-upgrade.css")) {
+  failures.push("Frontend upgrade layer missing: `assets/css/site-upgrade.css`.");
+} else {
+  const upgradeCss = read("assets/css/site-upgrade.css");
+  for (const requiredSelector of [
+    "article:has(.header-bar) .post-list",
+    "article:has(.header-bar) .featured-posts .row",
+    "body:has(.cv) .sticky-top::-webkit-scrollbar",
+    "content-visibility: auto",
+    "prefers-reduced-motion",
+  ]) {
+    if (!upgradeCss.includes(requiredSelector)) {
+      failures.push(`Frontend upgrade CSS must keep selector/contract: \`${requiredSelector}\`.`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated `site-upgrade.css` layer for professional frontend refinements without taking ownership of al-folio internals
- fix Blog index optical alignment by giving featured cards and regular post cards one shared content column and responsive grid behavior
- remove the visible native CV sidebar scrollbar while preserving sidebar scroll behavior
- add a restrained visual-system pass: quieter surfaces, clearer focus states, softer card depth, improved repository/project card rhythm, and mobile CTA layout
- add light rendering/performance improvements with `content-visibility` and reduced-motion fallbacks
- rewrite README so the repository presents as Hao's Notes / Zhihao Liu's public knowledge base instead of a thin theme leftover
- add current product/app projects to `/repositories/`: RhythmCoach, FlappyK, Ownly, and iCal Pro for Obsidian
- add product entry links on repository cards, including app/plugin CTAs in addition to source-code links
- add vanity redirect pages for `/FlappyK/`, `/RhythmCoach/`, `/ownly/`, and `/obsidian-ical-pro/`
- harden CI with frontend contract checks, scoped JS formatting check, and Ruby syntax validation before production build

## Visual design direction
- Positioning: a quiet professional portfolio / public knowledge base, not a loud product landing page.
- Layout: one disciplined optical content column for Blog, Repositories, Projects, and CV pages.
- Components: card-based but low-shadow, with hairline borders and restrained hover lift.
- Interaction: visible keyboard focus states, reduced-motion support, and product CTAs that stand apart from source-code links.
- CV sidebar: no visible scrollbar; the directory remains scrollable but no longer shows the heavy browser-native control.

## Design notes
- Keeps the previous `site-polish.css` layer intact and adds `site-upgrade.css` as a later, reversible overlay.
- Avoids copying `_layouts`, `_includes`, or theme-owned assets.
- Uses page-scoped selectors (`article:has(.header-bar)`, `body:has(.cv)`) to avoid affecting unrelated pages.
- Repository cards now distinguish product entry points from GitHub source-code links.

## Vanity URL note
- The new `/FlappyK/`, `/RhythmCoach/`, `/ownly/`, and `/obsidian-ical-pro/` pages are lightweight redirects from the main site.
- For the address bar to remain on `zhihaol.eu.org/<project>/`, the project build artifacts would need to be copied into the main `notes` Pages build, or served behind a path-aware proxy/CDN. This PR deliberately uses the safer redirect approach first.

## Verification
- Initial CI failed in the new verify step because the broad Prettier check was too brittle for existing repo formatting.
- Follow-up commit narrowed the formatting gate to `test/style_contract.js` and keeps the stronger contract/syntax checks.
- CI should run:
  - `npm run lint:style-contract`
  - `npx prettier --check test/style_contract.js`
  - `ruby -c _plugins/site_visual_polish.rb`
  - `bundle exec jekyll build`
  - `purgecss -c purgecss.config.js`

## Manual review after deploy
- `/blog/`: featured cards and post list should align to the same optical width.
- `/cv/`: the left sidebar should remain scrollable but should not show the heavy scrollbar from the screenshot.
- `/repositories/`: new product projects should appear at the top with app/plugin CTAs.
- `/projects/`, `/repositories/`, `/`: verify that the quieter card/shadow system improves hierarchy without making the site feel over-designed.
- `/FlappyK/`, `/RhythmCoach/`, `/ownly/`, `/obsidian-ical-pro/`: each should redirect to the corresponding product page.