### PR TITLE
Establish Hao's Notes redesign foundation

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -26,7 +26,8 @@ module SiteVisualPolish
 
   STYLESHEETS = [
     "site-polish.css",
-    "site-upgrade.css"
+    "site-upgrade.css",
+    "hao-design.css"
   ].freeze
 
   def self.apply_cv_title(page)

--- a/assets/css/hao-design.css
+++ b/assets/css/hao-design.css
@@ -1,0 +1,186 @@
+/*
+ * Hao's Notes design system foundation
+ *
+ * al-folio remains the Jekyll/runtime layer. This file is the first
+ * canonical Hao-owned visual layer and should become the long-term
+ * design contract for the site.
+ */
+
+:root {
+  --hao-page-max: min(100%, 68rem);
+  --hao-content-max: min(100%, 62rem);
+  --hao-reading-max: min(100%, 46rem);
+  --hao-radius-sm: 6px;
+  --hao-radius-md: 10px;
+  --hao-radius-lg: 16px;
+  --hao-border-subtle: color-mix(in srgb, var(--global-divider-color, rgba(15, 23, 42, 0.14)) 72%, transparent);
+  --hao-surface-base: var(--global-bg-color, #fff);
+  --hao-surface-soft: color-mix(in srgb, var(--global-text-color, #111827) 2.2%, transparent);
+  --hao-surface-hover: color-mix(in srgb, var(--global-theme-color, #2f6fed) 6%, transparent);
+  --hao-text-muted: color-mix(in srgb, var(--global-text-color, #111827) 66%, transparent);
+  --hao-shadow-card: 0 10px 30px rgba(15, 23, 42, 0.045);
+  --hao-shadow-card-hover: 0 16px 44px rgba(15, 23, 42, 0.082);
+  --hao-focus-ring: 0 0 0 3px color-mix(in srgb, var(--global-theme-color, #2f6fed) 18%, transparent);
+  --hao-space-section: clamp(2rem, 4vw, 3.25rem);
+  --hao-space-card: clamp(1rem, 2vw, 1.25rem);
+}
+
+html[data-theme="dark"] {
+  --hao-border-subtle: color-mix(in srgb, var(--global-divider-color, rgba(255, 255, 255, 0.16)) 80%, transparent);
+  --hao-surface-soft: color-mix(in srgb, var(--global-text-color, #f8fafc) 4%, transparent);
+  --hao-surface-hover: color-mix(in srgb, var(--global-theme-color, #7aa2ff) 12%, transparent);
+  --hao-shadow-card: 0 12px 32px rgba(0, 0, 0, 0.18);
+  --hao-shadow-card-hover: 0 18px 46px rgba(0, 0, 0, 0.26);
+}
+
+/* Global editorial rhythm */
+.post-header,
+.header-bar,
+.repo-page-intro,
+.projects,
+.repo-section,
+article > .post-content,
+article > .clearfix,
+article > .lead,
+.cv {
+  max-width: var(--hao-content-max);
+}
+
+.post-header .post-title,
+.header-bar h1,
+article h1,
+article h2,
+article h3 {
+  letter-spacing: -0.018em;
+}
+
+.post-header .post-description,
+.header-bar h2,
+.repo-page-intro,
+article > .lead {
+  color: var(--hao-text-muted);
+}
+
+article p,
+article li {
+  text-wrap: pretty;
+}
+
+/* Canonical Hao card surface */
+.featured-posts .card,
+.post-list > li,
+.projects .card,
+.repo-card,
+.repo-profile-card,
+.repo-trophy-card,
+.cv .card {
+  border-color: var(--hao-border-subtle) !important;
+  border-radius: var(--hao-radius-md) !important;
+  background: linear-gradient(180deg, var(--hao-surface-base), var(--hao-surface-soft));
+  box-shadow: none;
+}
+
+.featured-posts a:hover .card,
+.post-list > li:hover,
+.projects a:hover .card,
+.repo-card:hover {
+  box-shadow: var(--hao-shadow-card-hover);
+}
+
+/* Canonical Hao links and CTAs */
+article a,
+.repo-card__cta,
+.home-social-cta__primary {
+  text-underline-offset: 4px;
+}
+
+article a:focus-visible,
+.repo-card__cta:focus-visible,
+.home-social-cta__primary:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible {
+  border-radius: var(--hao-radius-sm);
+  outline: none;
+  box-shadow: var(--hao-focus-ring);
+}
+
+.repo-card__cta--primary {
+  border-radius: 999px;
+  font-weight: 650;
+}
+
+/* Product/app repository cards should be scan-friendly and not template-heavy. */
+.repo-card__chips {
+  gap: 0.42rem;
+}
+
+.repo-chip {
+  border-color: var(--hao-border-subtle);
+  background: color-mix(in srgb, var(--hao-surface-soft) 70%, transparent);
+}
+
+.repo-card__summary p,
+.projects .card-text,
+.post-list > li > p:not(.post-meta):not(.post-tags) {
+  color: var(--hao-text-muted);
+}
+
+/* CV remains formal, but visually belongs to Hao's Notes. */
+body:has(.cv) nav[data-toggle="toc"],
+body:has(.cv) #toc-sidebar,
+body:has(.cv) .toc-sidebar {
+  border-radius: var(--hao-radius-md);
+}
+
+body:has(.cv) nav[data-toggle="toc"] a:hover,
+body:has(.cv) #toc-sidebar a:hover,
+body:has(.cv) .toc-sidebar a:hover {
+  background: var(--hao-surface-hover);
+}
+
+/* Prevent regression to a visible heavy native scrollbar in the CV sidebar. */
+body:has(.cv) #toc-sidebar,
+body:has(.cv) .toc-sidebar,
+body:has(.cv) nav[data-toggle="toc"],
+body:has(.cv) .sticky-top {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+body:has(.cv) #toc-sidebar::-webkit-scrollbar,
+body:has(.cv) .toc-sidebar::-webkit-scrollbar,
+body:has(.cv) nav[data-toggle="toc"]::-webkit-scrollbar,
+body:has(.cv) .sticky-top::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+@media (max-width: 767px) {
+  :root {
+    --hao-space-section: 2rem;
+  }
+
+  .post-header,
+  .header-bar,
+  .repo-page-intro,
+  .projects,
+  .repo-section,
+  article > .post-content,
+  article > .clearfix,
+  article > .lead,
+  .cv {
+    max-width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .featured-posts .card,
+  .post-list > li,
+  .projects .card,
+  .repo-card,
+  .home-social-cta__primary,
+  .repo-card__cta--primary {
+    transition: none !important;
+  }
+}

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,139 @@
+# Hao's Notes Design System
+
+Hao's Notes is no longer treated as an al-folio visual variant. The site should now be maintained as an independent personal knowledge site, professional portfolio, and product directory. al-folio remains useful as a Jekyll/runtime layer, but it should not define the site's visual identity or information architecture.
+
+## Design positioning
+
+**Calm, editorial, technical, product-aware.**
+
+The site should feel like a quiet professional workspace: readable, precise, credible, and easy to scan. It should not feel like a loud SaaS landing page, a generic academic template, or a portfolio overloaded with animation.
+
+## Design principles
+
+1. **Content first** — typography, spacing, and hierarchy should make writing and project information easy to read.
+2. **One optical system** — Home, Blog, Projects, Repositories, and CV should feel like one site, not theme fragments.
+3. **Product-aware, not product-hype** — FlappyK, RhythmCoach, Ownly, and iCal Pro can have product CTAs, but cards should remain restrained.
+4. **Local ownership over upstream inheritance** — new visual decisions belong to Hao's Notes, not al-folio defaults.
+5. **Accessible by default** — keyboard focus, reduced motion, dark mode, and mobile layout are part of the design system, not afterthoughts.
+
+## Subagent contracts
+
+### Design Systems subagent
+
+Owns the visual language:
+
+- typography scale and line height;
+- page width and reading width;
+- spacing rhythm;
+- card surfaces, borders, radius, and shadows;
+- CTA hierarchy;
+- focus states;
+- dark mode parity.
+
+Deliverables should be expressed through `assets/css/hao-design.css` and this document.
+
+### Frontend Architecture subagent
+
+Owns implementation boundaries:
+
+- keep al-folio as runtime only;
+- avoid copying `_layouts`, `_includes`, `_sass`, or upstream assets unless the page is intentionally localized;
+- prefer Hao-specific classes and variables over brittle upstream selectors;
+- keep `site-polish.css` and `site-upgrade.css` as transitional layers until the design system can absorb them safely;
+- document every new layer in the style contract.
+
+### Content / IA subagent
+
+Owns site structure and content clarity:
+
+- Homepage should introduce who Zhihao is, what he builds, and where to go next;
+- Repositories should separate products/apps from research code and utility projects;
+- Projects should read as a portfolio narrative, not a raw archive;
+- Blog should feel editorial and readable;
+- CV should remain formal, but visually native to Hao's Notes.
+
+### QA / Performance subagent
+
+Owns guardrails:
+
+- preserve GitHub Pages deploy;
+- preserve dark mode;
+- preserve mobile layout;
+- preserve keyboard focus;
+- preserve reduced-motion support;
+- prevent native CV scrollbar regressions;
+- avoid unbounded visual effects and heavyweight assets;
+- expand `test/style_contract.js` when design-system assumptions become important.
+
+## Core tokens
+
+The canonical Hao layer is `assets/css/hao-design.css`. It should define tokens with the `--hao-*` prefix. Existing `--note-*` variables may remain during transition but should not be the long-term source of truth.
+
+Recommended token groups:
+
+```css
+--hao-page-max
+--hao-reading-max
+--hao-radius-sm
+--hao-radius-md
+--hao-radius-lg
+--hao-border-subtle
+--hao-surface-base
+--hao-surface-soft
+--hao-surface-hover
+--hao-shadow-card
+--hao-shadow-card-hover
+--hao-focus-ring
+--hao-space-section
+--hao-space-card
+```
+
+## Page contracts
+
+### Home
+
+Home is the front door. It should answer:
+
+- Who is this person?
+- What does he build?
+- What should I open next?
+
+It should not be only a CV-like academic about page.
+
+### Blog
+
+Blog is editorial. It should prioritize:
+
+- clear list rhythm;
+- readable titles;
+- useful summaries;
+- tags/categories as navigation aids, not decoration;
+- comfortable reading width.
+
+### Projects
+
+Projects are portfolio narratives. Cards should make categories and relevance obvious.
+
+### Repositories
+
+Repositories are product and code entry points. Product/app cards can expose primary CTAs such as `Open app`, `Play game`, or `Open plugin`, while still retaining source-code links.
+
+### CV
+
+CV remains formal. It should be clean, readable, and aligned with the site's visual system. The left navigation must remain scrollable without showing a heavy native scrollbar.
+
+## Migration policy
+
+Do not perform a full rewrite in one PR. Use this sequence:
+
+1. add independent Hao design tokens and contract;
+2. migrate repeated visual rules from `site-upgrade.css` into `hao-design.css` when safe;
+3. localize page layouts only when a page requires structural control;
+4. remove obsolete al-folio-specific overrides after visual parity is confirmed.
+
+## Non-goals
+
+- Do not chase upstream al-folio visual updates.
+- Do not migrate to Next.js, Astro, or another framework unless the Jekyll runtime becomes a bottleneck.
+- Do not embed separate app builds into the main site unless a future multi-app publishing plan is approved.
+- Do not add heavy animation, large JS dependencies, or decorative visual noise.

--- a/docs/REDESIGN_ROADMAP.md
+++ b/docs/REDESIGN_ROADMAP.md
@@ -1,0 +1,155 @@
+# Hao's Notes Redesign Roadmap
+
+This roadmap turns Hao's Notes from an al-folio-styled academic site into an independent personal knowledge site and product-aware portfolio.
+
+## Current state
+
+- al-folio remains the Jekyll runtime and plugin base.
+- `site-polish.css` contains earlier visual fixes.
+- `site-upgrade.css` contains the first modern visual-system pass, product repository CTAs, CV scrollbar removal, and performance/accessibility refinements.
+- `hao-design.css` is the new design-system foundation layer and should become the long-term local visual contract.
+
+## Workstream A — Design Systems subagent
+
+### A1. Foundation
+
+- Add design positioning and contracts.
+- Define `--hao-*` design tokens.
+- Establish page-width, card, CTA, focus, and CV sidebar rules.
+
+### A2. Consolidation
+
+- Audit `site-polish.css` and `site-upgrade.css`.
+- Move stable repeated patterns into `hao-design.css`.
+- Keep only legacy compatibility shims in older files.
+
+### A3. Finalization
+
+- Produce one clear public style guide for future agents.
+- Remove obsolete token duplication after pages are visually verified.
+
+## Workstream B — Frontend Architecture subagent
+
+### B1. Runtime boundary
+
+- Keep al-folio as a runtime and plugin system.
+- Avoid upstream chasing.
+- Do not copy theme internals unless a page must become locally owned.
+
+### B2. Local page ownership
+
+Prioritize pages in this order:
+
+1. Repositories
+2. Homepage
+3. Blog
+4. Projects
+5. CV
+
+For each page, decide whether CSS-only control is enough or whether a local layout/component should be introduced.
+
+### B3. Contract testing
+
+- Expand `test/style_contract.js` for design-system invariants.
+- Guard against missing `hao-design.css` injection.
+- Guard against visible CV sidebar scrollbar regressions.
+- Guard against deleting reduced-motion and focus rules.
+
+## Workstream C — Content / IA subagent
+
+### C1. Homepage
+
+Reframe homepage around:
+
+- professional identity;
+- key domains: climate/energy data, geospatial ML, CCUS/dMRV, offshore/geophysics, agent-native tools;
+- featured products/projects;
+- latest writing.
+
+### C2. Repositories
+
+Group repositories into:
+
+- Products & Apps: FlappyK, RhythmCoach, Ownly, iCal Pro;
+- Agent & Knowledge Tools: Ductor, Obsidian gateway, GhostCam;
+- Climate / Energy / Geoscience: CCUS Policy Hub, 4D Seismic Hub, Ice Block Expedition;
+- Teaching / Archive: GEO4300, Open Phrasebank, older experiments.
+
+### C3. Projects
+
+Make projects read as a portfolio:
+
+- what problem each project solves;
+- why it matters;
+- what the user can open or learn;
+- how it connects to the overall identity.
+
+### C4. Blog
+
+Make the blog feel editorial:
+
+- clearer category navigation;
+- better summary rhythm;
+- improved reading width;
+- stronger distinction between essays, notes, release posts, and technical logs.
+
+## Workstream D — QA / Performance subagent
+
+### D1. Required checks
+
+Every design PR should verify:
+
+- GitHub Pages build;
+- `npm run lint:style-contract`;
+- `ruby -c _plugins/site_visual_polish.rb`;
+- dark mode smoke check;
+- mobile viewport smoke check;
+- `/`, `/blog/`, `/projects/`, `/repositories/`, `/cv/` manual review.
+
+### D2. Performance and accessibility
+
+Preserve:
+
+- `content-visibility: auto` for long card lists;
+- reduced motion fallbacks;
+- visible keyboard focus states;
+- lazy-loaded external cards/images;
+- no heavyweight animation frameworks.
+
+## Proposed PR sequence
+
+### PR A — redesign foundation
+
+- Add `DESIGN_SYSTEM.md`.
+- Add this roadmap.
+- Add `hao-design.css`.
+- Inject `hao-design.css` after existing layers.
+- Extend style contract checks.
+
+### PR B — repositories as product directory
+
+- Split `/repositories/` into explicit groups.
+- Promote products/apps as first-class cards.
+- Preserve GitHub stats fallback.
+
+### PR C — homepage as front door
+
+- Rewrite homepage structure.
+- Add featured work section.
+- Add product/project entry points.
+
+### PR D — blog/projects editorial pass
+
+- Improve blog index and post reading system.
+- Rebalance project grouping and card summaries.
+
+### PR E — CV page ownership
+
+- Modernize the CV page inside the Hao design system.
+- Keep printable/exported CV unaffected.
+
+## Decision log
+
+- 2026-08-01: Freeze al-folio as visual source of truth. al-folio remains runtime only.
+- 2026-08-01: Keep product vanity URLs as safe redirects, not embedded multi-app publishing.
+- 2026-08-01: Use incremental PRs; avoid a full framework migration.

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -85,7 +85,7 @@ for (const requiredPath of ["test/visual", "test/integration_plugin_toggles.sh",
 }
 
 const visualPlugin = read("_plugins/site_visual_polish.rb");
-for (const stylesheet of ["site-polish.css", "site-upgrade.css"]) {
+for (const stylesheet of ["site-polish.css", "site-upgrade.css", "hao-design.css"]) {
   if (!visualPlugin.includes(stylesheet)) {
     failures.push(`Site visual polish plugin must inject \`${stylesheet}\`.`);
   }
@@ -105,6 +105,30 @@ if (!exists("assets/css/site-upgrade.css")) {
     if (!upgradeCss.includes(requiredSelector)) {
       failures.push(`Frontend upgrade CSS must keep selector/contract: \`${requiredSelector}\`.`);
     }
+  }
+}
+
+if (!exists("assets/css/hao-design.css")) {
+  failures.push("Hao design system layer missing: `assets/css/hao-design.css`.");
+} else {
+  const haoDesignCss = read("assets/css/hao-design.css");
+  for (const requiredSelector of [
+    "--hao-page-max",
+    "--hao-reading-max",
+    "--hao-focus-ring",
+    "body:has(.cv) .sticky-top::-webkit-scrollbar",
+    "scrollbar-width: none",
+    "prefers-reduced-motion",
+  ]) {
+    if (!haoDesignCss.includes(requiredSelector)) {
+      failures.push(`Hao design CSS must keep token/contract: \`${requiredSelector}\`.`);
+    }
+  }
+}
+
+for (const requiredDoc of ["docs/DESIGN_SYSTEM.md", "docs/REDESIGN_ROADMAP.md"]) {
+  if (!exists(requiredDoc)) {
+    failures.push(`Hao redesign documentation missing required path: \`${requiredDoc}\`.`);
   }
 }
 


### PR DESCRIPTION
## Summary
- add `docs/DESIGN_SYSTEM.md` to formally detach Hao's Notes visual direction from upstream al-folio
- add `docs/REDESIGN_ROADMAP.md` with subagent workstreams for design systems, frontend architecture, content/IA, and QA/performance
- add `assets/css/hao-design.css` as the first canonical Hao-owned design-system layer
- inject `hao-design.css` after the existing `site-polish.css` and `site-upgrade.css` layers
- extend `test/style_contract.js` to require the Hao design layer, documentation, CV scrollbar-hide contract, focus ring token, and reduced-motion guard

## Subagent split

### Design Systems subagent
- Defines the visual positioning: calm, editorial, technical, product-aware.
- Establishes the first `--hao-*` token set for width, radius, borders, surfaces, shadows, focus, and spacing.

### Frontend Architecture subagent
- Keeps al-folio as runtime only.
- Adds `hao-design.css` as a later override layer, without copying upstream layouts/includes/sass.
- Keeps current polish/upgrade files as transitional layers.

### Content / IA subagent
- Documents the next IA targets: homepage front door, product-aware repositories, editorial blog, portfolio projects, native CV.

### QA / Performance subagent
- Extends style contracts so the new design layer cannot be accidentally removed.
- Preserves reduced motion and the CV sidebar no-scrollbar requirement.

## Verification
- Not run locally in this environment.
- CI should run:
  - `npm run lint:style-contract`
  - `npx prettier --check test/style_contract.js`
  - `ruby -c _plugins/site_visual_polish.rb`
  - `bundle exec jekyll build`
  - `purgecss -c purgecss.config.js`

## Notes
- Repository Issues are disabled, so the subagent work breakdown is tracked in the roadmap file rather than GitHub issues.
- This is PR A only. It intentionally avoids rewriting homepage/repositories/blog/CV structure in the same PR.