### PR TITLE
Introduce Mission Log homepage shell

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,6 +1,6 @@
 ---
 layout: about
-title: About
+title: Hao's Notes
 permalink: /
 nav_order: 0
 subtitle: Climate & Energy Data Scientist
@@ -13,7 +13,7 @@ profile:
   more_info: >
     <p>📍Offshore Bergen, 2020 Aug</p>
 
-news: true # includes a list of news items
+news: true # Step 2 will reframe this as CURRENT OPERATIONS / 01
 announcements:
   enabled: true
   scrollable: false
@@ -24,15 +24,67 @@ latest_posts:
   scrollable: true
   limit: 4
 
-selected_papers: true # includes a list of papers marked as "selected={true}"
-projects: false # includes projects
-display_categories: [work] # Projects show in about page
+selected_papers: true # Step 3 will reframe this as RESEARCH RECORD / 05
+projects: false # Step 4 will selectively compose projects and repositories into SELECTED DEPLOYMENTS / 02-04
+display_categories: [work]
 social: true # rendered from _data/socials.yml
 home_cta: true
 ---
 
-<div class="home-intro">
-  <p>I build data workflows for climate and energy problems where the data is spatial, uncertain, and expensive to get wrong.</p>
-  <p>My work sits between remote sensing, geophysical monitoring, and applied machine learning. Recent projects include snow-depth downscaling from satellite laser altimetry, CCUS MRV workflows, and 4D seismic monitoring for subsurface assets.</p>
-  <p>This site collects my notes, projects, publications, and selected code. You can find formal research outputs in <a href="{{ '/publications/' | relative_url }}">publications</a>, tools and source code in <a href="{{ '/repositories/' | relative_url }}">repositories</a>, and working notes on the <a href="{{ '/blog/' | relative_url }}">blog</a>.</p>
+<div class="mission-log-home">
+  <section class="mission-cover" aria-labelledby="mission-cover-title">
+    <div class="mission-section-kicker">COVER / 00</div>
+    <h1 id="mission-cover-title">Small systems, field notes, and decision tools.</h1>
+    <p class="mission-cover__subtitle">Recorded from the edge of climate, geospatial intelligence, and AI productivity.</p>
+    <p class="mission-cover__note">A continuous mission log of what I am building, researching, and observing across data systems, energy transition questions, and AI-native personal tools.</p>
+    <div class="mission-cover__actions" aria-label="Mission log shortcuts">
+      <a class="mission-button mission-button--primary" href="#current-operations">Enter log</a>
+      <a class="mission-button" href="{{ '/blog/' | relative_url }}">Read notes</a>
+      <a class="mission-button" href="{{ '/repositories/' | relative_url }}">Repository archive</a>
+    </div>
+  </section>
+
+  <section class="mission-index" aria-labelledby="mission-index-title">
+    <div class="mission-section-kicker">MISSION INDEX</div>
+    <h2 id="mission-index-title">A long-form homepage in progress</h2>
+    <p>The home page is being rebuilt as the primary narrative surface for Hao's Notes. It will absorb selected projects, repositories, research outputs, field observations, career trajectory, and contact paths while keeping the full archive pages available in the background.</p>
+    <div class="mission-index__grid">
+      <a class="mission-index__item" href="#current-operations">
+        <span>CURRENT OPERATIONS / 01</span>
+        <strong>Active task log</strong>
+      </a>
+      <a class="mission-index__item" href="{{ '/projects/' | relative_url }}">
+        <span>SELECTED DEPLOYMENTS / 02-04</span>
+        <strong>Systems and tools</strong>
+      </a>
+      <a class="mission-index__item" href="{{ '/publications/' | relative_url }}">
+        <span>RESEARCH RECORD / 05</span>
+        <strong>Research outputs</strong>
+      </a>
+      <a class="mission-index__item" href="{{ '/blog/' | relative_url }}">
+        <span>FIELD OBSERVATIONS / 06</span>
+        <strong>Notes and essays</strong>
+      </a>
+      <a class="mission-index__item" href="{{ '/cv/' | relative_url }}">
+        <span>CAREER TRAJECTORY / 07</span>
+        <strong>Full CV archive</strong>
+      </a>
+      <a class="mission-index__item" href="#contact-back-cover">
+        <span>CONTACT / BACK COVER</span>
+        <strong>Links and contact</strong>
+      </a>
+    </div>
+  </section>
+
+  <section id="current-operations" class="mission-section mission-section--placeholder" aria-labelledby="current-operations-title">
+    <div class="mission-section-kicker">CURRENT OPERATIONS / 01</div>
+    <h2 id="current-operations-title">Active tasks and systems in motion</h2>
+    <p>This section will replace the legacy news rhythm with a concise task-log view of what is currently live, in progress, or under research.</p>
+  </section>
+
+  <section id="contact-back-cover" class="mission-section mission-section--placeholder" aria-labelledby="contact-back-cover-title">
+    <div class="mission-section-kicker">CONTACT / BACK COVER</div>
+    <h2 id="contact-back-cover-title">End of log</h2>
+    <p>For collaboration, project questions, research discussions, or independent-tool support, use the contact and archive links below.</p>
+  </section>
 </div>

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -4,7 +4,7 @@ title: Projects
 nav_title: Projects
 permalink: /projects/
 description: Selected projects in climate, geospatial ML, and decision tooling. Focused on high-stakes energy transition applications.
-nav: true
+nav: false
 nav_order: 2
 year_categories: [2025-2026, 2023-2024, 2022, 2019-2020]
 horizontal: false
@@ -47,9 +47,7 @@ horizontal: false
 {%- assign sorted_projects = site.projects | sort: "importance" -%}
 
   <!-- Generate cards for each project -->
-
-{% if page.horizontal -%}
-
+  {% if page.horizontal -%}
   <div class="container">
     <div class="row row-cols-2">
     {%- for project in sorted_projects -%}
@@ -64,7 +62,6 @@ horizontal: false
     {%- endfor %}
   </div>
   {%- endif -%}
-{%- endif -%}
-</div>
 
----
+{%- endif %}
+</div>

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -4,7 +4,7 @@ permalink: /repositories/
 title: Repositories
 nav_title: Repositories
 description: Selected open-source repositories and code projects.
-nav: true
+nav: false
 nav_order: 3
 ---
 

--- a/assets/css/hao-design.css
+++ b/assets/css/hao-design.css
@@ -23,6 +23,9 @@
   --hao-focus-ring: 0 0 0 3px color-mix(in srgb, var(--global-theme-color, #2f6fed) 18%, transparent);
   --hao-space-section: clamp(2rem, 4vw, 3.25rem);
   --hao-space-card: clamp(1rem, 2vw, 1.25rem);
+  --hao-mission-accent: var(--global-theme-color, #7c3aed);
+  --hao-mission-soft: color-mix(in srgb, var(--hao-mission-accent) 8%, transparent);
+  --hao-mission-line: color-mix(in srgb, var(--hao-mission-accent) 24%, transparent);
 }
 
 html[data-theme="dark"] {
@@ -31,6 +34,8 @@ html[data-theme="dark"] {
   --hao-surface-hover: color-mix(in srgb, var(--global-theme-color, #7aa2ff) 12%, transparent);
   --hao-shadow-card: 0 12px 32px rgba(0, 0, 0, 0.18);
   --hao-shadow-card-hover: 0 18px 46px rgba(0, 0, 0, 0.26);
+  --hao-mission-soft: color-mix(in srgb, var(--hao-mission-accent) 16%, transparent);
+  --hao-mission-line: color-mix(in srgb, var(--hao-mission-accent) 36%, transparent);
 }
 
 /* Global editorial rhythm */
@@ -109,6 +114,167 @@ button:focus-visible,
   font-weight: 650;
 }
 
+/* Mission Log homepage shell */
+.mission-log-home {
+  max-width: var(--hao-content-max);
+  margin: clamp(1.5rem, 4vw, 3rem) 0 var(--hao-space-section);
+}
+
+.mission-cover,
+.mission-index,
+.mission-section {
+  position: relative;
+  border: 1px solid var(--hao-border-subtle);
+  border-radius: var(--hao-radius-lg);
+  background:
+    radial-gradient(circle at 18% 0%, var(--hao-mission-soft), transparent 36%),
+    linear-gradient(180deg, var(--hao-surface-base), var(--hao-surface-soft));
+  box-shadow: var(--hao-shadow-card);
+}
+
+.mission-cover {
+  padding: clamp(1.45rem, 4vw, 2.8rem);
+  overflow: hidden;
+}
+
+.mission-cover::after {
+  content: "";
+  position: absolute;
+  right: clamp(-5rem, -8vw, -2rem);
+  bottom: clamp(-5rem, -9vw, -2rem);
+  width: min(24rem, 60vw);
+  aspect-ratio: 1;
+  border: 1px solid var(--hao-mission-line);
+  border-radius: 50%;
+  background:
+    linear-gradient(90deg, transparent 49%, var(--hao-mission-line) 50%, transparent 51%),
+    linear-gradient(0deg, transparent 49%, var(--hao-mission-line) 50%, transparent 51%);
+  opacity: 0.46;
+  pointer-events: none;
+}
+
+.mission-section-kicker {
+  color: var(--hao-mission-accent);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.14em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.mission-cover h1 {
+  max-width: 44rem;
+  margin: 0.75rem 0 0;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.mission-cover__subtitle {
+  max-width: 42rem;
+  margin: 1rem 0 0;
+  color: var(--global-text-color, #111827);
+  font-size: clamp(1.05rem, 2.1vw, 1.45rem);
+  line-height: 1.35;
+}
+
+.mission-cover__note,
+.mission-index p,
+.mission-section p {
+  max-width: var(--hao-reading-max);
+  color: var(--hao-text-muted);
+}
+
+.mission-cover__note {
+  margin-top: 1rem;
+}
+
+.mission-cover__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.35rem;
+}
+
+.mission-button {
+  display: inline-flex;
+  min-height: 2.45rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--hao-border-subtle);
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  color: var(--global-text-color, #111827);
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.mission-button:hover {
+  border-color: var(--hao-mission-line);
+  background: var(--hao-mission-soft);
+  text-decoration: none;
+}
+
+.mission-button--primary {
+  border-color: var(--hao-mission-accent);
+  background: var(--hao-mission-accent);
+  color: var(--global-bg-color, #fff);
+}
+
+.mission-index,
+.mission-section {
+  margin-top: 1rem;
+  padding: clamp(1.15rem, 3vw, 1.75rem);
+}
+
+.mission-index h2,
+.mission-section h2 {
+  margin: 0.45rem 0 0.55rem;
+  font-size: clamp(1.35rem, 3vw, 2.1rem);
+}
+
+.mission-index__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+  margin-top: 1.25rem;
+}
+
+.mission-index__item {
+  display: block;
+  border: 1px solid var(--hao-border-subtle);
+  border-radius: var(--hao-radius-md);
+  padding: 0.85rem 0.95rem;
+  background: color-mix(in srgb, var(--hao-surface-base) 82%, var(--hao-mission-soft));
+  text-decoration: none;
+}
+
+.mission-index__item:hover {
+  border-color: var(--hao-mission-line);
+  background: var(--hao-mission-soft);
+  text-decoration: none;
+}
+
+.mission-index__item span {
+  display: block;
+  color: var(--hao-mission-accent);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.mission-index__item strong {
+  display: block;
+  margin-top: 0.28rem;
+  color: var(--global-text-color, #111827);
+  font-size: 0.98rem;
+}
+
+.mission-section--placeholder {
+  border-style: dashed;
+}
+
 /* Product/app repository cards should be scan-friendly and not template-heavy. */
 .repo-card__chips {
   gap: 0.42rem;
@@ -169,8 +335,17 @@ body:has(.cv) .sticky-top::-webkit-scrollbar {
   article > .post-content,
   article > .clearfix,
   article > .lead,
-  .cv {
+  .cv,
+  .mission-log-home {
     max-width: 100%;
+  }
+
+  .mission-index__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mission-button {
+    width: 100%;
   }
 }
 
@@ -180,7 +355,9 @@ body:has(.cv) .sticky-top::-webkit-scrollbar {
   .projects .card,
   .repo-card,
   .home-social-cta__primary,
-  .repo-card__cta--primary {
+  .repo-card__cta--primary,
+  .mission-button,
+  .mission-index__item {
     transition: none !important;
   }
 }

--- a/cv.md
+++ b/cv.md
@@ -2,7 +2,7 @@
 layout: cv
 permalink: /cv/
 title: CV
-nav: true
+nav: false
 nav_order: 4
 cv_pdf: /assets/pdf/CV_Zhihao_geoscience.pdf
 cv_format: rendercv

--- a/docs/MISSION_LOG_PLAN.md
+++ b/docs/MISSION_LOG_PLAN.md
@@ -1,0 +1,202 @@
+# Mission Log homepage rollout
+
+Hao's Notes is moving from a conventional personal homepage toward a long-form mission log: a continuous primary narrative page that absorbs selected projects, repositories, research records, field observations, career trajectory, and contact paths while preserving the full archive pages in the background.
+
+The goal is not to replace the site's visual identity. The goal is to preserve the existing restrained purple/white Hao's Notes brand and gradually make the homepage feel more like a precise, technology-forward field dossier.
+
+## Navigation principle
+
+Projects, Repositories, and CV remain live archive pages, but they should no longer dominate the top-level navigation. The homepage becomes the primary narrative surface; archive pages become supporting records.
+
+## Subagent ownership
+
+### UI / Design Systems subagent
+
+Owns the Mission Log visual grammar:
+
+- section labels such as `COVER / 00` and `CURRENT OPERATIONS / 01`
+- purple accent language, thin dividers, quiet dossier-like surfaces
+- homepage spacing, section rhythm, and mobile behavior
+- visual restraint so the page does not become a SaaS dashboard or institutional portal
+
+### Content / IA subagent
+
+Owns the narrative structure:
+
+- long-form reading order
+- manual prioritization of selected deployments
+- transformation of News into task log entries
+- transformation of Publications into Research Record
+- transformation of CV into stage-based Career Trajectory
+
+### Frontend Architecture subagent
+
+Owns safe implementation:
+
+- keep al-folio as runtime only
+- avoid copying theme layouts unless needed in a later dedicated PR
+- prefer local data files and page-scoped CSS
+- preserve archive URLs and redirects
+
+### QA / Performance subagent
+
+Owns regression prevention:
+
+- update contract tests when adding new homepage structures
+- keep keyboard focus, reduced motion, and mobile layout working
+- preserve CI build and Pages deployment stability
+
+## Rollout stages
+
+### Step 1 — Mission Log UI shell
+
+Introduce the homepage as a mission log without moving all content yet.
+
+Scope:
+
+- add `COVER / 00`
+- add mission statement:
+  - `Small systems, field notes, and decision tools.`
+  - `Recorded from the edge of climate, geospatial intelligence, and AI productivity.`
+- add a Mission Index
+- hide Projects / Repositories / CV from top navigation while keeping their pages live
+- add Mission Log CSS primitives to `hao-design.css`
+- protect the new shell with style contract checks
+
+PR target: `Introduce Mission Log homepage shell`
+
+### Step 2 — Current Operations
+
+Reframe the legacy News area as a task log.
+
+Target section:
+
+`CURRENT OPERATIONS / 01`
+
+Scope:
+
+- create `_data/current_operations.yml`
+- replace dated news rhythm with operation entries
+- each entry should include operation id, title, status, summary, and link
+- keep tone concise and active
+
+Example:
+
+```text
+OP-01
+CCUS Policy Hub
+LIVE / MAINTAINING
+Expanding the public-facing policy and project intelligence layer for CCUS.
+```
+
+PR target: `Reframe News as Current Operations`
+
+### Step 3 — Selected Deployments
+
+Move selected Projects and Repositories into the homepage as manually prioritized deployed systems.
+
+Target sections:
+
+- `SELECTED DEPLOYMENTS / 02`
+- `SELECTED DEPLOYMENTS / 03`
+- `SELECTED DEPLOYMENTS / 04`
+
+Scope:
+
+- create or extend local data for selected deployments
+- manually order by strategic importance, not by date or GitHub metadata
+- include project/repo archive links, but do not list everything on the homepage
+- keep `/projects/` and `/repositories/` as full archives
+
+Primary candidates:
+
+- CCUS Policy Hub
+- Ownly
+- FlappyK
+- RhythmCoach
+- iCal Pro
+- AlphaEngine
+- 4D Seismic Hub
+- http-to-obsidian-cli-gateway
+
+PR target: `Add Selected Deployments to Mission Log`
+
+### Step 4 — Research Record
+
+Reframe selected publications and deep research outputs as a research record.
+
+Target section:
+
+`RESEARCH RECORD / 05`
+
+Scope:
+
+- keep formal publications available
+- present selected outputs as research records, not a citation list
+- include CCUS / dMRV, geospatial systems, 4D seismic, climate and energy intelligence
+- link to full publications archive where needed
+
+PR target: `Transform Publications into Research Record`
+
+### Step 5 — Field Observations
+
+Reframe selected notes and essays as field observations.
+
+Target section:
+
+`FIELD OBSERVATIONS / 06`
+
+Scope:
+
+- show selected notes, essays, build logs, market/system observations
+- organize by judgment and relevance rather than chronological completeness
+- link to full Notes / Blog archive
+
+PR target: `Add Field Observations section`
+
+### Step 6 — Career Trajectory
+
+Extract the CV into stage-based narrative.
+
+Target section:
+
+`CAREER TRAJECTORY / 07`
+
+Scope:
+
+- do not copy full CV into homepage
+- create a stage narrative:
+  - Foundations
+  - Field Work
+  - Research
+  - Builder Phase
+- link to full CV archive and CV PDF
+
+PR target: `Reframe CV as Career Trajectory`
+
+### Step 7 — Contact / Back Cover
+
+Turn the ending of the page into a designed back cover.
+
+Target section:
+
+`CONTACT / BACK COVER`
+
+Scope:
+
+- create a closing paragraph and contact link set
+- include Email, GitHub, Zenodo, CV, Ko-fi, and selected archive links
+- make the ending feel like the back cover of a field dossier, not a generic footer
+
+PR target: `Add Mission Log Back Cover`
+
+## Acceptance criteria for the whole redesign
+
+The final homepage should:
+
+- feel like a continuous primary narrative page
+- preserve the existing Hao's Notes brand tone
+- avoid institutional or SaaS-dashboard aesthetics
+- make Projects / Repositories / CV accessible but no longer dominant in nav
+- explain what is active now, what has been deployed, what has been researched, what is being observed, and how the path formed
+- remain readable, mobile-friendly, and CI-safe

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -116,6 +116,10 @@ if (!exists("assets/css/hao-design.css")) {
     "--hao-page-max",
     "--hao-reading-max",
     "--hao-focus-ring",
+    "--hao-mission-accent",
+    ".mission-log-home",
+    ".mission-section-kicker",
+    ".mission-index__grid",
     "body:has(.cv) .sticky-top::-webkit-scrollbar",
     "scrollbar-width: none",
     "prefers-reduced-motion",
@@ -126,7 +130,30 @@ if (!exists("assets/css/hao-design.css")) {
   }
 }
 
-for (const requiredDoc of ["docs/DESIGN_SYSTEM.md", "docs/REDESIGN_ROADMAP.md"]) {
+const aboutPage = read("_pages/about.md");
+for (const requiredHomeMarker of [
+  "COVER / 00",
+  "Small systems, field notes, and decision tools.",
+  "Recorded from the edge of climate, geospatial intelligence, and AI productivity.",
+  "CURRENT OPERATIONS / 01",
+  "SELECTED DEPLOYMENTS / 02-04",
+  "RESEARCH RECORD / 05",
+  "FIELD OBSERVATIONS / 06",
+  "CAREER TRAJECTORY / 07",
+  "CONTACT / BACK COVER",
+]) {
+  if (!aboutPage.includes(requiredHomeMarker)) {
+    failures.push(`Mission Log homepage must keep marker: \`${requiredHomeMarker}\`.`);
+  }
+}
+
+for (const hiddenNavPage of ["_pages/projects.md", "_pages/repositories.md", "cv.md"]) {
+  if (!/^nav:\s*false$/m.test(read(hiddenNavPage))) {
+    failures.push(`Mission Log nav strategy requires \`${hiddenNavPage}\` to keep \`nav: false\`.`);
+  }
+}
+
+for (const requiredDoc of ["docs/DESIGN_SYSTEM.md", "docs/REDESIGN_ROADMAP.md", "docs/MISSION_LOG_PLAN.md"]) {
   if (!exists(requiredDoc)) {
     failures.push(`Hao redesign documentation missing required path: \`${requiredDoc}\`.`);
   }

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -143,7 +143,9 @@ for (const requiredHomeMarker of [
   "CONTACT / BACK COVER",
 ]) {
   if (!aboutPage.includes(requiredHomeMarker)) {
-    failures.push(`Mission Log homepage must keep marker: \`${requiredHomeMarker}\`.`);
+    failures.push(
+      `Mission Log homepage must keep marker: \`${requiredHomeMarker}\`.`,
+    );
   }
 }
 
@@ -153,7 +155,9 @@ for (const hiddenNavPage of [
   "cv.md",
 ]) {
   if (!/^nav:\s*false$/m.test(read(hiddenNavPage))) {
-    failures.push(`Mission Log nav strategy requires \`${hiddenNavPage}\` to keep \`nav: false\`.`);
+    failures.push(
+      `Mission Log nav strategy requires \`${hiddenNavPage}\` to keep \`nav: false\`.`,
+    );
   }
 }
 
@@ -163,7 +167,9 @@ for (const requiredDoc of [
   "docs/MISSION_LOG_PLAN.md",
 ]) {
   if (!exists(requiredDoc)) {
-    failures.push(`Hao redesign documentation missing required path: \`${requiredDoc}\`.`);
+    failures.push(
+      `Hao redesign documentation missing required path: \`${requiredDoc}\`.`,
+    );
   }
 }
 

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -131,6 +131,7 @@ if (!exists("assets/css/hao-design.css")) {
 }
 
 const aboutPage = read("_pages/about.md");
+// prettier-ignore
 for (const requiredHomeMarker of [
   "COVER / 00",
   "Small systems, field notes, and decision tools.",
@@ -149,6 +150,7 @@ for (const requiredHomeMarker of [
   }
 }
 
+// prettier-ignore
 for (const hiddenNavPage of [
   "_pages/projects.md",
   "_pages/repositories.md",
@@ -161,6 +163,7 @@ for (const hiddenNavPage of [
   }
 }
 
+// prettier-ignore
 for (const requiredDoc of [
   "docs/DESIGN_SYSTEM.md",
   "docs/REDESIGN_ROADMAP.md",

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -147,13 +147,21 @@ for (const requiredHomeMarker of [
   }
 }
 
-for (const hiddenNavPage of ["_pages/projects.md", "_pages/repositories.md", "cv.md"]) {
+for (const hiddenNavPage of [
+  "_pages/projects.md",
+  "_pages/repositories.md",
+  "cv.md",
+]) {
   if (!/^nav:\s*false$/m.test(read(hiddenNavPage))) {
     failures.push(`Mission Log nav strategy requires \`${hiddenNavPage}\` to keep \`nav: false\`.`);
   }
 }
 
-for (const requiredDoc of ["docs/DESIGN_SYSTEM.md", "docs/REDESIGN_ROADMAP.md", "docs/MISSION_LOG_PLAN.md"]) {
+for (const requiredDoc of [
+  "docs/DESIGN_SYSTEM.md",
+  "docs/REDESIGN_ROADMAP.md",
+  "docs/MISSION_LOG_PLAN.md",
+]) {
   if (!exists(requiredDoc)) {
     failures.push(`Hao redesign documentation missing required path: \`${requiredDoc}\`.`);
   }


### PR DESCRIPTION
## Summary
- introduce the first Mission Log homepage shell with `COVER / 00`, a Mission Index, placeholder `CURRENT OPERATIONS / 01`, and `CONTACT / BACK COVER`
- set the cover language to: `Small systems, field notes, and decision tools.` / `Recorded from the edge of climate, geospatial intelligence, and AI productivity.`
- hide Projects, Repositories, and CV from the primary navigation while keeping `/projects/`, `/repositories/`, and `/cv/` live as archives
- add Mission Log visual primitives to `assets/css/hao-design.css`: section kickers, mission surfaces, purple accent tokens, dossier-style cards, and mobile fallbacks
- add `docs/MISSION_LOG_PLAN.md` with the full staged rollout plan for Current Operations, Selected Deployments, Research Record, Field Observations, Career Trajectory, and Back Cover
- extend `test/style_contract.js` so future agents preserve Mission Log markers, hidden archive nav strategy, design CSS tokens, and rollout documentation

## Subagent split

### UI / Design Systems subagent
- Creates the Mission Log visual grammar while preserving the existing Hao’s Notes brand tone.
- Keeps the page personal, precise, and purple-accented rather than institutional or dashboard-like.

### Content / IA subagent
- Establishes the long-form reading order and section vocabulary.
- Leaves the full content migration to later focused PRs.

### Frontend Architecture subagent
- Uses the existing about page and `hao-design.css` overlay rather than copying theme layouts.
- Keeps archive pages reachable and stable.

### QA / Performance subagent
- Adds contract checks for homepage markers, hidden nav pages, reduced-motion preservation, and documentation.

## Rollout sequence after this PR
1. Reframe News as `CURRENT OPERATIONS / 01`.
2. Add manually prioritized `SELECTED DEPLOYMENTS / 02–04` from Projects and Repositories.
3. Transform Selected Publications into `RESEARCH RECORD / 05`.
4. Add selected notes as `FIELD OBSERVATIONS / 06`.
5. Reframe CV as `CAREER TRAJECTORY / 07`.
6. Finish `CONTACT / BACK COVER` as the homepage closing surface.

## Verification
- Not run locally in this environment.
- CI should run:
  - `npm run lint:style-contract`
  - `npx prettier --check test/style_contract.js`
  - `ruby -c _plugins/site_visual_polish.rb`
  - `bundle exec jekyll build`
  - `purgecss -c purgecss.config.js`

## Notes
- This is intentionally Step 1 only. It does not yet migrate News, Publications, Projects, Repositories, or CV content into their final Mission Log sections.