### PR TITLE
Reframe news as Current Operations log

### DIFF
--- a/_data/current_operations.yml
+++ b/_data/current_operations.yml
@@ -1,0 +1,31 @@
+operations:
+  - id: OP-01
+    title: CCUS Policy Hub
+    status: LIVE / MAINTAINING
+    summary: Maintaining a public-facing policy and project intelligence layer for CCUS deployment, regulation, and dMRV evidence.
+    href: https://liuh886.github.io/ccus-policy-hub/
+    label: Open system
+  - id: OP-02
+    title: Ownly
+    status: IN PROGRESS
+    summary: Building a local-first ownership memory system across Obsidian, web, and agent-readable CLI surfaces.
+    href: https://liuh886.github.io/ownly/
+    label: Open app
+  - id: OP-03
+    title: FlappyK
+    status: LIVE / ITERATING
+    summary: Testing a market-intuition game around hidden historical K-line decisions, positive excess return, and lightweight play.
+    href: https://liuh886.github.io/FlappyK/
+    label: Play game
+  - id: OP-04
+    title: RhythmCoach
+    status: BETA
+    summary: Refining a lightweight rhythm and speech-practice tool with simple onboarding, PWA installation, and focused review.
+    href: https://liuh886.github.io/RhythmCoach/
+    label: Open app
+  - id: OP-05
+    title: AlphaEngine
+    status: RESEARCH
+    summary: Investigating practical routes toward durable alpha discovery, cleaner data foundations, and reproducible strategy records.
+    href: https://github.com/liuh886/alpha_engine
+    label: View repository

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -13,7 +13,7 @@ profile:
   more_info: >
     <p>📍Offshore Bergen, 2020 Aug</p>
 
-news: true # Step 2 will reframe this as CURRENT OPERATIONS / 01
+news: false # replaced by CURRENT OPERATIONS / 01 mission log
 announcements:
   enabled: true
   scrollable: false
@@ -76,10 +76,27 @@ home_cta: true
     </div>
   </section>
 
-  <section id="current-operations" class="mission-section mission-section--placeholder" aria-labelledby="current-operations-title">
+  <section id="current-operations" class="mission-section mission-section--operations" aria-labelledby="current-operations-title">
     <div class="mission-section-kicker">CURRENT OPERATIONS / 01</div>
     <h2 id="current-operations-title">Active tasks and systems in motion</h2>
-    <p>This section will replace the legacy news rhythm with a concise task-log view of what is currently live, in progress, or under research.</p>
+    <p class="mission-section__intro">A compact task log of the systems that are live, in progress, or under research right now.</p>
+    <div class="operations-log" aria-label="Current operations">
+      {% for operation in site.data.current_operations.operations %}
+        <article class="operations-log__entry">
+          <div class="operations-log__meta">
+            <span>{{ operation.id }}</span>
+            <strong>{{ operation.status }}</strong>
+          </div>
+          <div class="operations-log__body">
+            <h3>{{ operation.title }}</h3>
+            <p>{{ operation.summary }}</p>
+            {% if operation.href %}
+              <a href="{{ operation.href }}" target="_blank" rel="noopener noreferrer">{{ operation.label | default: "Open" }} →</a>
+            {% endif %}
+          </div>
+        </article>
+      {% endfor %}
+    </div>
   </section>
 
   <section id="contact-back-cover" class="mission-section mission-section--placeholder" aria-labelledby="contact-back-cover-title">

--- a/assets/css/hao-design.css
+++ b/assets/css/hao-design.css
@@ -271,8 +271,61 @@ button:focus-visible,
   font-size: 0.98rem;
 }
 
+.mission-section__intro {
+  margin-bottom: 1.1rem;
+}
+
 .mission-section--placeholder {
   border-style: dashed;
+}
+
+.operations-log {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.15rem;
+}
+
+.operations-log__entry {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 0.34fr) minmax(0, 1fr);
+  gap: 1rem;
+  border: 1px solid var(--hao-border-subtle);
+  border-radius: var(--hao-radius-md);
+  padding: 0.95rem;
+  background: color-mix(in srgb, var(--hao-surface-base) 86%, var(--hao-mission-soft));
+}
+
+.operations-log__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--hao-mission-accent);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.operations-log__meta strong {
+  color: var(--hao-text-muted);
+  font-size: 0.68rem;
+  line-height: 1.25;
+}
+
+.operations-log__body h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.operations-log__body p {
+  margin: 0.35rem 0 0;
+}
+
+.operations-log__body a {
+  display: inline-flex;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 650;
 }
 
 /* Product/app repository cards should be scan-friendly and not template-heavy. */
@@ -340,7 +393,8 @@ body:has(.cv) .sticky-top::-webkit-scrollbar {
     max-width: 100%;
   }
 
-  .mission-index__grid {
+  .mission-index__grid,
+  .operations-log__entry {
     grid-template-columns: 1fr;
   }
 

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -120,6 +120,7 @@ if (!exists("assets/css/hao-design.css")) {
     ".mission-log-home",
     ".mission-section-kicker",
     ".mission-index__grid",
+    ".operations-log__entry",
     "body:has(.cv) .sticky-top::-webkit-scrollbar",
     "scrollbar-width: none",
     "prefers-reduced-motion",
@@ -142,11 +143,29 @@ for (const requiredHomeMarker of [
   "FIELD OBSERVATIONS / 06",
   "CAREER TRAJECTORY / 07",
   "CONTACT / BACK COVER",
+  "operations-log",
 ]) {
   if (!aboutPage.includes(requiredHomeMarker)) {
     failures.push(
       `Mission Log homepage must keep marker: \`${requiredHomeMarker}\`.`,
     );
+  }
+}
+
+if (!/^news:\s*false\b/m.test(aboutPage)) {
+  failures.push("Mission Log homepage must keep legacy `news` disabled after Step 2.");
+}
+if (!exists("_data/current_operations.yml")) {
+  failures.push("Mission Log current operations data missing: `_data/current_operations.yml`.");
+} else {
+  const currentOperations = read("_data/current_operations.yml");
+  // prettier-ignore
+  for (const requiredOperation of ["OP-01", "CCUS Policy Hub", "Ownly", "FlappyK", "RhythmCoach", "AlphaEngine"]) {
+    if (!currentOperations.includes(requiredOperation)) {
+      failures.push(
+        `Current operations log must keep operation marker: \`${requiredOperation}\`.`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add `_data/current_operations.yml` as the first Mission Log task-log data source
- disable legacy `news` rendering on the homepage
- replace the `CURRENT OPERATIONS / 01` placeholder with a real operations log for CCUS Policy Hub, Ownly, FlappyK, RhythmCoach, and AlphaEngine
- add operations-log visual treatment to `hao-design.css`
- extend `test/style_contract.js` so future edits preserve the Step 2 current-operations data and avoid regressing to ordinary news

## Subagent split

### Content / IA subagent
- Reframes homepage news as current operational status rather than announcements.
- Keeps entries concise, current-state oriented, and manually curated.

### UI / Design Systems subagent
- Adds operation log cards with mission-style IDs, status labels, and lightweight action links.
- Preserves the purple Mission Log visual language introduced in PR #52.

### Frontend Architecture subagent
- Uses a data file rather than hard-coded one-off content where possible.
- Keeps the legacy archive pages untouched.

### QA / Performance subagent
- Adds contract checks for `_data/current_operations.yml`, `news: false`, key operation names, and operations-log CSS.

## Verification
- Not run locally in this environment.
- CI should run the existing deploy workflow.

## Notes
- This is Step 2 only. Selected Deployments, Research Record, Field Observations, Career Trajectory, and Back Cover remain for later PRs.