### PR TITLE
Add Selected Deployments to Mission Log homepage

### DIFF
--- a/_data/selected_deployments.yml
+++ b/_data/selected_deployments.yml
@@ -1,0 +1,103 @@
+groups:
+  - id: "02"
+    kicker: SELECTED DEPLOYMENTS / 02
+    title: Primary systems
+    summary: Public-facing systems and products that best represent the current direction of Hao's Notes.
+    deployments:
+      - ref: D-02.01
+        title: CCUS Policy Hub
+        status: LIVE
+        kind: Climate intelligence / public data product
+        summary: A policy and project knowledge layer for CCUS deployment, regulation, and dMRV evidence.
+        href: https://liuh886.github.io/ccus-policy-hub/
+        primary_label: Open system
+        secondary_href: https://github.com/liuh886/ccus-policy-hub
+        secondary_label: Repository
+      - ref: D-02.02
+        title: Ownly
+        status: IN PROGRESS
+        kind: Local-first memory / personal systems
+        summary: Ownership memory for humans and AI agents, spanning Obsidian, web, and stable CLI JSON surfaces.
+        href: https://liuh886.github.io/ownly/
+        primary_label: Open app
+        secondary_href: https://github.com/liuh886/ownly
+        secondary_label: Repository
+      - ref: D-02.03
+        title: FlappyK
+        status: LIVE / ITERATING
+        kind: Market intuition game
+        summary: A browser game built around hidden historical K-lines, positive excess return, and lightweight decision practice.
+        href: https://liuh886.github.io/FlappyK/
+        primary_label: Play game
+        secondary_href: https://github.com/liuh886/FlappyK
+        secondary_label: Repository
+      - ref: D-02.04
+        title: RhythmCoach
+        status: BETA
+        kind: Speech rhythm / PWA practice tool
+        summary: A local-first speaking practice tool focused on rhythm, timing, recording, and post-session review.
+        href: https://liuh886.github.io/RhythmCoach/
+        primary_label: Open app
+        secondary_href: https://github.com/liuh886/RhythmCoach
+        secondary_label: Repository
+  - id: "03"
+    kicker: SELECTED DEPLOYMENTS / 03
+    title: Supporting tools and infrastructure
+    summary: Smaller systems, plugins, and research engines that support the wider one-person operating surface.
+    deployments:
+      - ref: D-03.01
+        title: iCal Pro for Obsidian
+        status: PLUGIN
+        kind: Markdown tasks to iCalendar feeds
+        summary: An Obsidian plugin that turns Markdown tasks into standards-compliant feeds for Google, Apple, Outlook, and other calendar clients.
+        href: https://obsidian.md/plugins?id=ical-plugin-pro
+        primary_label: Open plugin
+        secondary_href: https://github.com/liuh886/obsidian-ical-plugin-pro
+        secondary_label: Repository
+      - ref: D-03.02
+        title: AlphaEngine
+        status: RESEARCH
+        kind: Quant research / strategy records
+        summary: A research engine for factor experiments, backtests, strategy persistence, and reproducible alpha-discovery workflows.
+        href: https://github.com/liuh886/alpha_engine
+        primary_label: Repository
+      - ref: D-03.03
+        title: 4D Seismic Hub
+        status: KNOWLEDGE SYSTEM
+        kind: Geophysical monitoring knowledge base
+        summary: A best-practice 4D seismic exploration and monitoring knowledge base with AI-agent oriented interfaces.
+        href: https://github.com/liuh886/4d-seismic-hub
+        primary_label: Repository
+      - ref: D-03.04
+        title: HTTP to Obsidian CLI Gateway
+        status: TOOL
+        kind: Agent-to-vault bridge
+        summary: A lightweight HTTP proxy that lets sandboxed AI agents safely reach a host Obsidian CLI.
+        href: https://github.com/liuh886/http-to-obsidian-cli-gateway
+        primary_label: Repository
+  - id: "04"
+    kicker: SELECTED DEPLOYMENTS / 04
+    title: Open-source footprint
+    summary: Selected repositories and public artifacts that show the technical substrate behind the main systems.
+    deployments:
+      - ref: D-04.01
+        title: GhostCam
+        status: WINDOWS TOOL
+        kind: Virtual camera / real-time background replacement
+        summary: An ultra-light Windows virtual camera for background replacement, blur, and solid-color background workflows.
+        href: https://github.com/liuh886/GhostCam
+        primary_label: Repository
+      - ref: D-04.02
+        title: Open Phrasebank
+        status: OPEN SOURCE
+        kind: Writing system / phrase extraction
+        summary: A custom phrasebank generation workflow built from selected texts and corpora.
+        href: https://github.com/liuh886/open-phrasebank
+        primary_label: Repository
+      - ref: D-04.03
+        title: GEO4300 2023
+        status: TEACHING
+        kind: Geophysical data science exercises
+        summary: Exercise templates and learning artifacts for GEO4300 Geophysical Data Science.
+        href: https://github.com/liuh886/GEO4300_2023
+        primary_label: Repository

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -24,8 +24,8 @@ latest_posts:
   scrollable: true
   limit: 4
 
-selected_papers: true # Step 3 will reframe this as RESEARCH RECORD / 05
-projects: false # Step 4 will selectively compose projects and repositories into SELECTED DEPLOYMENTS / 02-04
+selected_papers: true # Step 4 will reframe this as RESEARCH RECORD / 05
+projects: false # selected deployments are now composed manually below
 display_categories: [work]
 social: true # rendered from _data/socials.yml
 home_cta: true
@@ -53,7 +53,7 @@ home_cta: true
         <span>CURRENT OPERATIONS / 01</span>
         <strong>Active task log</strong>
       </a>
-      <a class="mission-index__item" href="{{ '/projects/' | relative_url }}">
+      <a class="mission-index__item" href="#selected-deployments">
         <span>SELECTED DEPLOYMENTS / 02-04</span>
         <strong>Systems and tools</strong>
       </a>
@@ -96,6 +96,48 @@ home_cta: true
           </div>
         </article>
       {% endfor %}
+    </div>
+  </section>
+
+  <section id="selected-deployments" class="mission-section mission-section--deployments" aria-labelledby="selected-deployments-title">
+    <div class="mission-section-kicker">SELECTED DEPLOYMENTS / 02-04</div>
+    <h2 id="selected-deployments-title">Manually prioritized systems and technical assets</h2>
+    <p class="mission-section__intro">Selected deployments are ordered by importance rather than repository chronology. Full project and repository archives remain available as supporting records.</p>
+    <div class="deployments-log">
+      {% for group in site.data.selected_deployments.groups %}
+        <section class="deployments-group" aria-labelledby="deployment-group-{{ group.id }}">
+          <div class="deployments-group__header">
+            <span>{{ group.kicker }}</span>
+            <h3 id="deployment-group-{{ group.id }}">{{ group.title }}</h3>
+            <p>{{ group.summary }}</p>
+          </div>
+          <div class="deployments-grid">
+            {% for deployment in group.deployments %}
+              <article class="deployment-card">
+                <div class="deployment-card__meta">
+                  <span>{{ deployment.ref }}</span>
+                  <strong>{{ deployment.status }}</strong>
+                </div>
+                <h4>{{ deployment.title }}</h4>
+                <p class="deployment-card__kind">{{ deployment.kind }}</p>
+                <p>{{ deployment.summary }}</p>
+                <div class="deployment-card__actions">
+                  {% if deployment.href %}
+                    <a href="{{ deployment.href }}" target="_blank" rel="noopener noreferrer">{{ deployment.primary_label | default: "Open" }} →</a>
+                  {% endif %}
+                  {% if deployment.secondary_href %}
+                    <a href="{{ deployment.secondary_href }}" target="_blank" rel="noopener noreferrer">{{ deployment.secondary_label | default: "Repository" }} →</a>
+                  {% endif %}
+                </div>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
+      {% endfor %}
+    </div>
+    <div class="mission-archive-links" aria-label="Full archives">
+      <a href="{{ '/projects/' | relative_url }}">Full project archive →</a>
+      <a href="{{ '/repositories/' | relative_url }}">Repository archive →</a>
     </div>
   </section>
 

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -27,7 +27,8 @@ module SiteVisualPolish
   STYLESHEETS = [
     "site-polish.css",
     "site-upgrade.css",
-    "hao-design.css"
+    "hao-design.css",
+    "mission-log-deployments.css"
   ].freeze
 
   def self.apply_cv_title(page)

--- a/assets/css/mission-log-deployments.css
+++ b/assets/css/mission-log-deployments.css
@@ -1,0 +1,125 @@
+/*
+ * Mission Log deployments layer
+ *
+ * Focused styles for SELECTED DEPLOYMENTS / 02-04. Kept separate from
+ * hao-design.css so the base design-system layer remains readable.
+ */
+
+.deployments-log {
+  display: grid;
+  gap: 1.15rem;
+  margin-top: 1.25rem;
+}
+
+.deployments-group {
+  border-top: 1px solid var(--hao-mission-line);
+  padding-top: 1.1rem;
+}
+
+.deployments-group:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.deployments-group__header {
+  max-width: var(--hao-reading-max);
+}
+
+.deployments-group__header span,
+.deployment-card__meta span {
+  color: var(--hao-mission-accent);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.deployments-group__header h3 {
+  margin: 0.25rem 0 0.35rem;
+  font-size: clamp(1.1rem, 2.3vw, 1.45rem);
+}
+
+.deployments-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin-top: 0.9rem;
+}
+
+.deployment-card {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  border: 1px solid var(--hao-border-subtle);
+  border-radius: var(--hao-radius-md);
+  padding: 0.95rem;
+  background:
+    radial-gradient(circle at 0% 0%, var(--hao-mission-soft), transparent 34%),
+    color-mix(in srgb, var(--hao-surface-base) 88%, var(--hao-mission-soft));
+}
+
+.deployment-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.7rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.deployment-card__meta strong {
+  border: 1px solid var(--hao-mission-line);
+  border-radius: 999px;
+  padding: 0.14rem 0.45rem;
+  color: var(--hao-mission-accent);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.deployment-card h4 {
+  margin: 0.65rem 0 0.2rem;
+  font-size: 1.06rem;
+}
+
+.deployment-card__kind {
+  margin: 0 0 0.35rem;
+  color: var(--global-text-color, #111827) !important;
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.deployment-card > p:not(.deployment-card__kind) {
+  flex: 1 1 auto;
+}
+
+.deployment-card__actions,
+.mission-archive-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.9rem;
+  margin-top: 0.75rem;
+}
+
+.deployment-card__actions a,
+.mission-archive-links a {
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+.mission-archive-links {
+  border-top: 1px solid var(--hao-border-subtle);
+  padding-top: 1rem;
+}
+
+@media (max-width: 767px) {
+  .deployments-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deployment-card {
+    transition: none !important;
+  }
+}

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -85,7 +85,12 @@ for (const requiredPath of ["test/visual", "test/integration_plugin_toggles.sh",
 }
 
 const visualPlugin = read("_plugins/site_visual_polish.rb");
-for (const stylesheet of ["site-polish.css", "site-upgrade.css", "hao-design.css"]) {
+for (const stylesheet of [
+  "site-polish.css",
+  "site-upgrade.css",
+  "hao-design.css",
+  "mission-log-deployments.css",
+]) {
   if (!visualPlugin.includes(stylesheet)) {
     failures.push(`Site visual polish plugin must inject \`${stylesheet}\`.`);
   }
@@ -131,6 +136,18 @@ if (!exists("assets/css/hao-design.css")) {
   }
 }
 
+if (!exists("assets/css/mission-log-deployments.css")) {
+  failures.push("Mission Log deployments style layer missing: `assets/css/mission-log-deployments.css`.");
+} else {
+  const deploymentsCss = read("assets/css/mission-log-deployments.css");
+  // prettier-ignore
+  for (const requiredSelector of [".deployments-log", ".deployments-group", ".deployment-card", ".mission-archive-links"]) {
+    if (!deploymentsCss.includes(requiredSelector)) {
+      failures.push(`Deployments CSS must keep selector: \`${requiredSelector}\`.`);
+    }
+  }
+}
+
 const aboutPage = read("_pages/about.md");
 // prettier-ignore
 for (const requiredHomeMarker of [
@@ -144,6 +161,8 @@ for (const requiredHomeMarker of [
   "CAREER TRAJECTORY / 07",
   "CONTACT / BACK COVER",
   "operations-log",
+  "selected-deployments",
+  "deployments-log",
 ]) {
   if (!aboutPage.includes(requiredHomeMarker)) {
     failures.push(
@@ -164,6 +183,20 @@ if (!exists("_data/current_operations.yml")) {
     if (!currentOperations.includes(requiredOperation)) {
       failures.push(
         `Current operations log must keep operation marker: \`${requiredOperation}\`.`,
+      );
+    }
+  }
+}
+
+if (!exists("_data/selected_deployments.yml")) {
+  failures.push("Mission Log selected deployments data missing: `_data/selected_deployments.yml`.");
+} else {
+  const selectedDeployments = read("_data/selected_deployments.yml");
+  // prettier-ignore
+  for (const requiredDeployment of ["D-02.01", "CCUS Policy Hub", "Ownly", "FlappyK", "RhythmCoach", "D-03.01", "iCal Pro", "4D Seismic Hub", "D-04.01", "GhostCam"]) {
+    if (!selectedDeployments.includes(requiredDeployment)) {
+      failures.push(
+        `Selected deployments log must keep deployment marker: \`${requiredDeployment}\`.`,
       );
     }
   }

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -85,12 +85,7 @@ for (const requiredPath of ["test/visual", "test/integration_plugin_toggles.sh",
 }
 
 const visualPlugin = read("_plugins/site_visual_polish.rb");
-for (const stylesheet of [
-  "site-polish.css",
-  "site-upgrade.css",
-  "hao-design.css",
-  "mission-log-deployments.css",
-]) {
+for (const stylesheet of ["site-polish.css", "site-upgrade.css", "hao-design.css"]) {
   if (!visualPlugin.includes(stylesheet)) {
     failures.push(`Site visual polish plugin must inject \`${stylesheet}\`.`);
   }
@@ -136,18 +131,6 @@ if (!exists("assets/css/hao-design.css")) {
   }
 }
 
-if (!exists("assets/css/mission-log-deployments.css")) {
-  failures.push("Mission Log deployments style layer missing: `assets/css/mission-log-deployments.css`.");
-} else {
-  const deploymentsCss = read("assets/css/mission-log-deployments.css");
-  // prettier-ignore
-  for (const requiredSelector of [".deployments-log", ".deployments-group", ".deployment-card", ".mission-archive-links"]) {
-    if (!deploymentsCss.includes(requiredSelector)) {
-      failures.push(`Deployments CSS must keep selector: \`${requiredSelector}\`.`);
-    }
-  }
-}
-
 const aboutPage = read("_pages/about.md");
 // prettier-ignore
 for (const requiredHomeMarker of [
@@ -161,8 +144,6 @@ for (const requiredHomeMarker of [
   "CAREER TRAJECTORY / 07",
   "CONTACT / BACK COVER",
   "operations-log",
-  "selected-deployments",
-  "deployments-log",
 ]) {
   if (!aboutPage.includes(requiredHomeMarker)) {
     failures.push(
@@ -183,20 +164,6 @@ if (!exists("_data/current_operations.yml")) {
     if (!currentOperations.includes(requiredOperation)) {
       failures.push(
         `Current operations log must keep operation marker: \`${requiredOperation}\`.`,
-      );
-    }
-  }
-}
-
-if (!exists("_data/selected_deployments.yml")) {
-  failures.push("Mission Log selected deployments data missing: `_data/selected_deployments.yml`.");
-} else {
-  const selectedDeployments = read("_data/selected_deployments.yml");
-  // prettier-ignore
-  for (const requiredDeployment of ["D-02.01", "CCUS Policy Hub", "Ownly", "FlappyK", "RhythmCoach", "D-03.01", "iCal Pro", "4D Seismic Hub", "D-04.01", "GhostCam"]) {
-    if (!selectedDeployments.includes(requiredDeployment)) {
-      failures.push(
-        `Selected deployments log must keep deployment marker: \`${requiredDeployment}\`.`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- add `_data/selected_deployments.yml` for manually prioritized deployments
- add `SELECTED DEPLOYMENTS / 02-04` to the homepage as curated systems, supporting infrastructure, and open-source footprint
- include archive links back to the full Projects and Repositories pages
- add `assets/css/mission-log-deployments.css` as a focused post-`hao-design.css` layer
- inject the deployments style layer through `_plugins/site_visual_polish.rb`
- extend frontend contracts to preserve selected deployment data, homepage markers, and the deployments CSS layer

## Subagent split

### Content / IA subagent
- Orders deployments by importance, not chronology or repository freshness.
- Separates primary systems, supporting tools, and open-source footprint.

### UI / Design Systems subagent
- Adds deployment cards with mission-style IDs, status pills, kind labels, and restrained action links.
- Keeps the design close to the Mission Log shell rather than SaaS-style cards.

### Frontend Architecture subagent
- Uses a data file for manually curated deployments.
- Keeps `/projects/` and `/repositories/` as hidden-but-live archives.

### QA / Performance subagent
- Adds contract checks for `_data/selected_deployments.yml`, deployment markers, and deployment CSS selectors.

## Verification
- Not run locally in this environment.
- CI should run the existing deploy workflow.

## Notes
- This is Step 3 only. Research Record, Field Observations, Career Trajectory, and Back Cover remain for later PRs.