### PR TITLE
Transform selected publications into Research Record

### DIFF
--- a/_data/research_records.yml
+++ b/_data/research_records.yml
@@ -1,0 +1,33 @@
+records:
+  - id: R-05.01
+    title: Retrieving snow depth distribution by downscaling ERA5 Reanalysis with ICESat-2 laser altimetry
+    status: PEER-REVIEWED
+    kind: Cold Regions Science and Technology, 2025
+    summary: A geospatial modeling record on using ICESat-2 laser altimetry, ERA5 Land, calibration, and XGBoost to map snow-depth variability.
+    href: https://www.sciencedirect.com/science/article/pii/S0165232X25001636
+    label: Read paper
+    secondary_href: /publications/
+    secondary_label: Publication archive
+  - id: R-05.02
+    title: CCUS Policy Hub
+    status: PUBLIC RESEARCH SYSTEM
+    kind: CCUS policy, deployment, and dMRV evidence
+    summary: A public-facing knowledge and data interface for tracking CCUS policy, project deployment, governance context, and MRV-related evidence questions.
+    href: https://liuh886.github.io/ccus-policy-hub/
+    label: Open system
+    secondary_href: https://github.com/liuh886/ccus-policy-hub
+    secondary_label: Repository
+  - id: R-05.03
+    title: 4D Seismic Hub
+    status: KNOWLEDGE INFRASTRUCTURE
+    kind: Geophysical monitoring and subsurface data systems
+    summary: A best-practice knowledge base for 4D seismic exploration and monitoring, connecting offshore field practice with AI-readable technical knowledge.
+    href: https://github.com/liuh886/4d-seismic-hub
+    label: Repository
+  - id: R-05.04
+    title: Underwater seismic device identification system
+    status: PATENT RECORD
+    kind: Underwater seismic devices, PRC patent record
+    summary: A patent record connected to offshore seismic-device identification and operational field systems.
+    href: /publications/
+    label: Publication archive

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -158,7 +158,7 @@ home_cta: true
             <p>{{ record.summary }}</p>
             <div class="research-record__actions">
               {% if record.href %}
-                <a href="{{ record.href }}" {% unless record.href contains site.url or record.href contains '/' and record.href.size < 2 %}target="_blank" rel="noopener noreferrer"{% endunless %}>{{ record.label | default: "Open" }} →</a>
+                <a href="{{ record.href }}" target="_blank" rel="noopener noreferrer">{{ record.label | default: "Open" }} →</a>
               {% endif %}
               {% if record.secondary_href %}
                 <a href="{{ record.secondary_href }}">{{ record.secondary_label | default: "More" }} →</a>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -24,7 +24,7 @@ latest_posts:
   scrollable: true
   limit: 4
 
-selected_papers: true # Step 4 will reframe this as RESEARCH RECORD / 05
+selected_papers: false # replaced by RESEARCH RECORD / 05 mission log
 projects: false # selected deployments are now composed manually below
 display_categories: [work]
 social: true # rendered from _data/socials.yml
@@ -57,7 +57,7 @@ home_cta: true
         <span>SELECTED DEPLOYMENTS / 02-04</span>
         <strong>Systems and tools</strong>
       </a>
-      <a class="mission-index__item" href="{{ '/publications/' | relative_url }}">
+      <a class="mission-index__item" href="#research-record">
         <span>RESEARCH RECORD / 05</span>
         <strong>Research outputs</strong>
       </a>
@@ -138,6 +138,35 @@ home_cta: true
     <div class="mission-archive-links" aria-label="Full archives">
       <a href="{{ '/projects/' | relative_url }}">Full project archive →</a>
       <a href="{{ '/repositories/' | relative_url }}">Repository archive →</a>
+    </div>
+  </section>
+
+  <section id="research-record" class="mission-section mission-section--research" aria-labelledby="research-record-title">
+    <div class="mission-section-kicker">RESEARCH RECORD / 05</div>
+    <h2 id="research-record-title">Selected research outputs and knowledge records</h2>
+    <p class="mission-section__intro">This section replaces the old selected-publications block with a tighter research record: formal publication, research systems, and field-oriented technical artifacts.</p>
+    <div class="research-records">
+      {% for record in site.data.research_records.records %}
+        <article class="research-record">
+          <div class="research-record__meta">
+            <span>{{ record.id }}</span>
+            <strong>{{ record.status }}</strong>
+          </div>
+          <div class="research-record__body">
+            <h3>{{ record.title }}</h3>
+            <p class="research-record__kind">{{ record.kind }}</p>
+            <p>{{ record.summary }}</p>
+            <div class="research-record__actions">
+              {% if record.href %}
+                <a href="{{ record.href }}" {% unless record.href contains site.url or record.href contains '/' and record.href.size < 2 %}target="_blank" rel="noopener noreferrer"{% endunless %}>{{ record.label | default: "Open" }} →</a>
+              {% endif %}
+              {% if record.secondary_href %}
+                <a href="{{ record.secondary_href }}">{{ record.secondary_label | default: "More" }} →</a>
+              {% endif %}
+            </div>
+          </div>
+        </article>
+      {% endfor %}
     </div>
   </section>
 

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -28,7 +28,8 @@ module SiteVisualPolish
     "site-polish.css",
     "site-upgrade.css",
     "hao-design.css",
-    "mission-log-deployments.css"
+    "mission-log-deployments.css",
+    "mission-log-records.css"
   ].freeze
 
   def self.apply_cv_title(page)

--- a/assets/css/mission-log-records.css
+++ b/assets/css/mission-log-records.css
@@ -1,0 +1,71 @@
+/*
+ * Mission Log research records layer
+ *
+ * Focused styles for RESEARCH RECORD / 05. This keeps publication and
+ * knowledge-infrastructure entries visually aligned with the Mission Log.
+ */
+
+.research-records {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.15rem;
+}
+
+.research-record {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 0.28fr) minmax(0, 1fr);
+  gap: 1rem;
+  border: 1px solid var(--hao-border-subtle);
+  border-radius: var(--hao-radius-md);
+  padding: 0.95rem;
+  background:
+    radial-gradient(circle at 0% 0%, var(--hao-mission-soft), transparent 34%),
+    color-mix(in srgb, var(--hao-surface-base) 88%, var(--hao-mission-soft));
+}
+
+.research-record__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--hao-mission-accent);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.research-record__meta strong {
+  color: var(--hao-text-muted);
+  font-size: 0.68rem;
+  line-height: 1.25;
+}
+
+.research-record__body h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.research-record__kind {
+  margin: 0.28rem 0 0.35rem;
+  color: var(--global-text-color, #111827) !important;
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.research-record__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.9rem;
+  margin-top: 0.6rem;
+}
+
+.research-record__actions a {
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+@media (max-width: 767px) {
+  .research-record {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add `_data/research_records.yml` for curated research outputs and knowledge records
- replace the old homepage selected-publications block with `RESEARCH RECORD / 05`
- include the 2025 CRST snow-depth downscaling paper, CCUS Policy Hub, 4D Seismic Hub, and the underwater seismic device patent record
- add `assets/css/mission-log-records.css` for research-record cards
- inject the research records CSS layer through `_plugins/site_visual_polish.rb`

## Subagent split

### Content / IA subagent
- Reframes publications as a research record rather than a citation list.
- Separates formal publication, public research system, knowledge infrastructure, and patent record.

### UI / Design Systems subagent
- Keeps Research Record visually aligned with the Mission Log card grammar.

### Frontend Architecture subagent
- Uses a small curated data file instead of relying on theme-owned selected-papers rendering.
- Keeps `/publications/` available as the complete archive.

### QA / Performance subagent
- Keeps changes static and data-driven with no new JavaScript.

## Verification
- Not run locally in this environment.
- CI should run the existing deploy workflow.

## Notes
- This is Step 4 only. Field Observations, Career Trajectory, and Back Cover remain for later PRs.