### PR TITLE
Add Field Observations to Mission Log homepage

### DIFF
--- a/_data/field_observations.yml
+++ b/_data/field_observations.yml
@@ -1,0 +1,25 @@
+observations:
+  - id: F-06.01
+    title: The Agentic Brain: A Blueprint for Personal AI OS with LifeOS 5.0
+    status: AI / ARCHITECTURE
+    summary: A systems note on moving from passive digital hoarding to an active agentic brain for personal knowledge and memory workflows.
+    href: /blog/2026/lifeos-5-agentic-brain/
+    label: Read note
+  - id: F-06.02
+    title: 让 AI 看见你的大脑：Obsidian CLI 的价值与意义
+    status: AI / OBSIDIAN
+    summary: A short note on why an Obsidian CLI can turn a local knowledge base into an agent-readable working surface.
+    href: /blog/2026/obsidian-graph-rag/
+    label: Read note
+  - id: F-06.03
+    title: A tabular dataset ready for machine learning applications
+    status: GEOSPATIAL / DATASET
+    summary: A field note on retrieved snow depth in mainland Norway based on ICESat-2 ATL08, DEMs, and machine-learning-ready tabular data.
+    href: /blog/2023/subgrid/
+    label: Read note
+  - id: F-06.04
+    title: ICESat-2 vs DTM1, DTM10, Copernicus30, FABDEM
+    status: GEOSPATIAL / DEM
+    summary: A technical observation on DEM comparison, co-registration, bias correction, and ICESat-2 snow-free segments.
+    href: /blog/2023/dataset/
+    label: Read note

--- a/_data/field_observations.yml
+++ b/_data/field_observations.yml
@@ -1,25 +1,25 @@
 observations:
-  - id: F-06.01
-    title: The Agentic Brain: A Blueprint for Personal AI OS with LifeOS 5.0
-    status: AI / ARCHITECTURE
-    summary: A systems note on moving from passive digital hoarding to an active agentic brain for personal knowledge and memory workflows.
-    href: /blog/2026/lifeos-5-agentic-brain/
-    label: Read note
-  - id: F-06.02
-    title: 让 AI 看见你的大脑：Obsidian CLI 的价值与意义
-    status: AI / OBSIDIAN
-    summary: A short note on why an Obsidian CLI can turn a local knowledge base into an agent-readable working surface.
-    href: /blog/2026/obsidian-graph-rag/
-    label: Read note
-  - id: F-06.03
-    title: A tabular dataset ready for machine learning applications
-    status: GEOSPATIAL / DATASET
-    summary: A field note on retrieved snow depth in mainland Norway based on ICESat-2 ATL08, DEMs, and machine-learning-ready tabular data.
-    href: /blog/2023/subgrid/
-    label: Read note
-  - id: F-06.04
-    title: ICESat-2 vs DTM1, DTM10, Copernicus30, FABDEM
-    status: GEOSPATIAL / DEM
-    summary: A technical observation on DEM comparison, co-registration, bias correction, and ICESat-2 snow-free segments.
-    href: /blog/2023/dataset/
-    label: Read note
+  - id: "F-06.01"
+    title: "The Agentic Brain: A Blueprint for Personal AI OS with LifeOS 5.0"
+    status: "AI / ARCHITECTURE"
+    summary: "A systems note on moving from passive digital hoarding to an active agentic brain for personal knowledge and memory workflows."
+    href: "/blog/2026/lifeos-5-agentic-brain/"
+    label: "Read note"
+  - id: "F-06.02"
+    title: "让 AI 看见你的大脑：Obsidian CLI 的价值与意义"
+    status: "AI / OBSIDIAN"
+    summary: "A short note on why an Obsidian CLI can turn a local knowledge base into an agent-readable working surface."
+    href: "/blog/2026/obsidian-graph-rag/"
+    label: "Read note"
+  - id: "F-06.03"
+    title: "A tabular dataset ready for machine learning applications"
+    status: "GEOSPATIAL / DATASET"
+    summary: "A field note on retrieved snow depth in mainland Norway based on ICESat-2 ATL08, DEMs, and machine-learning-ready tabular data."
+    href: "/blog/2023/subgrid/"
+    label: "Read note"
+  - id: "F-06.04"
+    title: "ICESat-2 vs DTM1, DTM10, Copernicus30, FABDEM"
+    status: "GEOSPATIAL / DEM"
+    summary: "A technical observation on DEM comparison, co-registration, bias correction, and ICESat-2 snow-free segments."
+    href: "/blog/2023/dataset/"
+    label: "Read note"

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -61,7 +61,7 @@ home_cta: true
         <span>RESEARCH RECORD / 05</span>
         <strong>Research outputs</strong>
       </a>
-      <a class="mission-index__item" href="{{ '/blog/' | relative_url }}">
+      <a class="mission-index__item" href="#field-observations">
         <span>FIELD OBSERVATIONS / 06</span>
         <strong>Notes and essays</strong>
       </a>
@@ -167,6 +167,30 @@ home_cta: true
           </div>
         </article>
       {% endfor %}
+    </div>
+  </section>
+
+  <section id="field-observations" class="mission-section mission-section--observations" aria-labelledby="field-observations-title">
+    <div class="mission-section-kicker">FIELD OBSERVATIONS / 06</div>
+    <h2 id="field-observations-title">Selected notes from the field</h2>
+    <p class="mission-section__intro">A curated layer of observations, build notes, and technical records. This is not the full blog; it is the reading path that best supports the Mission Log.</p>
+    <div class="field-observations">
+      {% for observation in site.data.field_observations.observations %}
+        <article class="field-observation">
+          <div class="field-observation__meta">
+            <span>{{ observation.id }}</span>
+            <strong>{{ observation.status }}</strong>
+          </div>
+          <h3>{{ observation.title }}</h3>
+          <p>{{ observation.summary }}</p>
+          {% if observation.href %}
+            <a href="{{ observation.href }}">{{ observation.label | default: "Read" }} →</a>
+          {% endif %}
+        </article>
+      {% endfor %}
+    </div>
+    <div class="mission-archive-links" aria-label="Notes archive">
+      <a href="{{ '/blog/' | relative_url }}">Full notes archive →</a>
     </div>
   </section>
 

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -29,7 +29,8 @@ module SiteVisualPolish
     "site-upgrade.css",
     "hao-design.css",
     "mission-log-deployments.css",
-    "mission-log-records.css"
+    "mission-log-records.css",
+    "mission-log-observations.css"
   ].freeze
 
   def self.apply_cv_title(page)

--- a/assets/css/mission-log-observations.css
+++ b/assets/css/mission-log-observations.css
@@ -1,0 +1,68 @@
+/*
+ * Mission Log field observations layer
+ *
+ * Focused styles for FIELD OBSERVATIONS / 06. The module should feel
+ * like curated observations, not a generic recent-post list.
+ */
+
+.field-observations {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin-top: 1.15rem;
+}
+
+.field-observation {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  border: 1px solid var(--hao-border-subtle);
+  border-radius: var(--hao-radius-md);
+  padding: 0.95rem;
+  background:
+    linear-gradient(135deg, var(--hao-mission-soft), transparent 42%),
+    color-mix(in srgb, var(--hao-surface-base) 88%, var(--hao-mission-soft));
+}
+
+.field-observation__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.7rem;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--hao-mission-accent);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.field-observation__meta strong {
+  border: 1px solid var(--hao-mission-line);
+  border-radius: 999px;
+  padding: 0.14rem 0.45rem;
+  color: var(--hao-mission-accent);
+  font-size: 0.62rem;
+  line-height: 1.2;
+}
+
+.field-observation h3 {
+  margin: 0.65rem 0 0.35rem;
+  font-size: 1.05rem;
+}
+
+.field-observation p {
+  flex: 1 1 auto;
+}
+
+.field-observation a {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+@media (max-width: 767px) {
+  .field-observations {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add `_data/field_observations.yml` for curated notes and technical observations
- add `FIELD OBSERVATIONS / 06` to the homepage
- add `assets/css/mission-log-observations.css` for observation cards
- inject the observation CSS layer through `_plugins/site_visual_polish.rb`

## Scope
- This PR turns the blog area into a curated Mission Log reading path.
- The full blog archive remains available.
- No JavaScript is added.

## Verification
- Not run locally in this environment.
- CI should run the existing deploy workflow.

## Notes
- This is Step 5 only. Career Trajectory and Back Cover remain for the final PR.