### PR TITLE
Refine Mission Log homepage visual direction

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -33,21 +33,51 @@ home_cta: true
 
 <div class="mission-log-home">
   <section class="mission-cover" aria-labelledby="mission-cover-title">
-    <div class="mission-section-kicker">COVER / 00</div>
-    <h1 id="mission-cover-title">Small systems, field notes, and decision tools.</h1>
-    <p class="mission-cover__subtitle">Recorded from the edge of climate, geospatial intelligence, and AI productivity.</p>
-    <p class="mission-cover__note">A continuous mission log of what I am building, researching, and observing across data systems, energy transition questions, and AI-native personal tools.</p>
-    <div class="mission-cover__actions" aria-label="Mission log shortcuts">
-      <a class="mission-button mission-button--primary" href="#current-operations">Enter log</a>
-      <a class="mission-button" href="{{ '/blog/' | relative_url }}">Read notes</a>
-      <a class="mission-button" href="{{ '/repositories/' | relative_url }}">Repository archive</a>
+    <div class="mission-cover__layout">
+      <div class="mission-cover__copy">
+        <div class="mission-section-kicker">COVER / 00</div>
+        <h1 id="mission-cover-title">Small systems, field notes, and decision tools.</h1>
+        <p class="mission-cover__subtitle">Recorded from the edge of climate, geospatial intelligence, and AI productivity.</p>
+        <p class="mission-cover__note">A personal mission log for the systems I build, the research I keep, and the observations that shape my work.</p>
+        <div class="mission-cover__actions" aria-label="Mission log shortcuts">
+          <a class="mission-button mission-button--primary" href="#current-operations">Enter log</a>
+          <a class="mission-button" href="{{ '/blog/' | relative_url }}">Read notes</a>
+          <a class="mission-button" href="{{ '/repositories/' | relative_url }}">Repository archive</a>
+        </div>
+      </div>
+      <aside class="mission-cover__visual" aria-label="Mission metadata">
+        <div class="mission-orbit" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+        <dl class="mission-cover__metadata">
+          <div>
+            <dt>LOG STATUS</dt>
+            <dd>ACTIVE</dd>
+          </div>
+          <div>
+            <dt>FIELD</dt>
+            <dd>CLIMATE · GEO · AI</dd>
+          </div>
+          <div>
+            <dt>MAINTAINED BY</dt>
+            <dd>ZHIHAO LIU</dd>
+          </div>
+        </dl>
+        <div class="mission-cover__chips" aria-hidden="true">
+          <span>systems</span>
+          <span>field notes</span>
+          <span>decision tools</span>
+        </div>
+      </aside>
     </div>
   </section>
 
   <section class="mission-index" aria-labelledby="mission-index-title">
     <div class="mission-section-kicker">MISSION INDEX</div>
-    <h2 id="mission-index-title">A long-form homepage in progress</h2>
-    <p>The home page is being rebuilt as the primary narrative surface for Hao's Notes. It now organizes current operations, deployed systems, research outputs, field observations, career trajectory, and contact paths while keeping full archive pages available in the background.</p>
+    <h2 id="mission-index-title">Reading sequence</h2>
+    <p>A compact route through current work, deployed systems, research records, field observations, career trajectory, and contact paths.</p>
     <div class="mission-index__grid">
       <a class="mission-index__item" href="#current-operations">
         <span>CURRENT OPERATIONS / 01</span>
@@ -79,7 +109,7 @@ home_cta: true
   <section id="current-operations" class="mission-section mission-section--operations" aria-labelledby="current-operations-title">
     <div class="mission-section-kicker">CURRENT OPERATIONS / 01</div>
     <h2 id="current-operations-title">Active tasks and systems in motion</h2>
-    <p class="mission-section__intro">A compact task log of the systems that are live, in progress, or under research right now.</p>
+    <p class="mission-section__intro">A task log of live, in-progress, and research systems.</p>
     <div class="operations-log" aria-label="Current operations">
       {% for operation in site.data.current_operations.operations %}
         <article class="operations-log__entry">
@@ -102,7 +132,7 @@ home_cta: true
   <section id="selected-deployments" class="mission-section mission-section--deployments" aria-labelledby="selected-deployments-title">
     <div class="mission-section-kicker">SELECTED DEPLOYMENTS / 02-04</div>
     <h2 id="selected-deployments-title">Manually prioritized systems and technical assets</h2>
-    <p class="mission-section__intro">Selected deployments are ordered by importance rather than repository chronology. Full project and repository archives remain available as supporting records.</p>
+    <p class="mission-section__intro">Selected systems ordered by importance rather than repository chronology.</p>
     <div class="deployments-log">
       {% for group in site.data.selected_deployments.groups %}
         <section class="deployments-group" aria-labelledby="deployment-group-{{ group.id }}">
@@ -144,7 +174,7 @@ home_cta: true
   <section id="research-record" class="mission-section mission-section--research" aria-labelledby="research-record-title">
     <div class="mission-section-kicker">RESEARCH RECORD / 05</div>
     <h2 id="research-record-title">Selected research outputs and knowledge records</h2>
-    <p class="mission-section__intro">This section replaces the old selected-publications block with a tighter research record: formal publication, research systems, and field-oriented technical artifacts.</p>
+    <p class="mission-section__intro">Formal publication, research systems, and field-oriented technical records.</p>
     <div class="research-records">
       {% for record in site.data.research_records.records %}
         <article class="research-record">
@@ -173,7 +203,7 @@ home_cta: true
   <section id="field-observations" class="mission-section mission-section--observations" aria-labelledby="field-observations-title">
     <div class="mission-section-kicker">FIELD OBSERVATIONS / 06</div>
     <h2 id="field-observations-title">Selected notes from the field</h2>
-    <p class="mission-section__intro">A curated layer of observations, build notes, and technical records. This is not the full blog; it is the reading path that best supports the Mission Log.</p>
+    <p class="mission-section__intro">A curated reading path through observations, build notes, and technical records.</p>
     <div class="field-observations">
       {% for observation in site.data.field_observations.observations %}
         <article class="field-observation">
@@ -197,7 +227,7 @@ home_cta: true
   <section id="career-trajectory" class="mission-section mission-section--trajectory" aria-labelledby="career-trajectory-title">
     <div class="mission-section-kicker">CAREER TRAJECTORY / 07</div>
     <h2 id="career-trajectory-title">How this path formed</h2>
-    <p class="mission-section__intro">A phase narrative rather than a full CV. The complete formal record remains available in the CV archive.</p>
+    <p class="mission-section__intro">A phase narrative; the complete formal record remains in the CV archive.</p>
     <div class="career-trajectory">
       {% for phase in site.data.career_trajectory.phases %}
         <article class="career-phase">

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -31,7 +31,8 @@ module SiteVisualPolish
     "mission-log-deployments.css",
     "mission-log-records.css",
     "mission-log-observations.css",
-    "mission-log-trajectory.css"
+    "mission-log-trajectory.css",
+    "mission-log-visual-pass.css"
   ].freeze
 
   def self.apply_cv_title(page)

--- a/assets/css/mission-log-visual-pass.css
+++ b/assets/css/mission-log-visual-pass.css
@@ -1,0 +1,448 @@
+/*
+ * Mission Log visual pass
+ *
+ * Product-design layer for turning the homepage from a structured log into
+ * a more intentional personal mission dossier. Loaded last by the visual
+ * polish plugin, so it only overrides the homepage presentation layer.
+ */
+
+.mission-log-home {
+  position: relative;
+  isolation: isolate;
+  max-width: min(100%, 72rem);
+  margin-top: clamp(1rem, 3vw, 2rem);
+}
+
+.mission-log-home::before {
+  content: "";
+  position: absolute;
+  inset: -1rem -2rem auto;
+  z-index: -1;
+  height: clamp(18rem, 38vw, 32rem);
+  background:
+    radial-gradient(circle at 16% 18%, color-mix(in srgb, var(--hao-mission-accent) 16%, transparent), transparent 30%),
+    radial-gradient(circle at 78% 8%, color-mix(in srgb, var(--hao-mission-accent) 10%, transparent), transparent 28%);
+  opacity: 0.78;
+  pointer-events: none;
+}
+
+.mission-cover {
+  min-height: clamp(30rem, 68vh, 43rem);
+  padding: clamp(1.2rem, 4vw, 3.5rem);
+  border-color: color-mix(in srgb, var(--hao-mission-accent) 26%, var(--hao-border-subtle));
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--hao-mission-accent) 5%, transparent) 1px, transparent 1px),
+    linear-gradient(0deg, color-mix(in srgb, var(--hao-mission-accent) 4%, transparent) 1px, transparent 1px),
+    radial-gradient(circle at 82% 22%, color-mix(in srgb, var(--hao-mission-accent) 18%, transparent), transparent 26%),
+    linear-gradient(135deg, var(--hao-surface-base), color-mix(in srgb, var(--hao-surface-base) 82%, var(--hao-mission-soft)) 58%, var(--hao-surface-soft));
+  background-size: 34px 34px, 34px 34px, auto, auto;
+}
+
+.mission-cover::after {
+  opacity: 0.24;
+}
+
+.mission-cover__layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  min-height: inherit;
+  grid-template-columns: minmax(0, 1.14fr) minmax(17rem, 0.86fr);
+  gap: clamp(1.6rem, 4vw, 3rem);
+  align-items: center;
+}
+
+.mission-cover__copy {
+  max-width: 48rem;
+}
+
+.mission-cover h1 {
+  max-width: 13ch;
+  font-size: clamp(3.1rem, 7.4vw, 6.35rem);
+  line-height: 0.92;
+  letter-spacing: -0.075em;
+}
+
+.mission-cover__subtitle {
+  max-width: 36rem;
+  margin-top: 1.2rem;
+  font-size: clamp(1.16rem, 2vw, 1.52rem);
+}
+
+.mission-cover__note {
+  max-width: 35rem;
+  font-size: 0.98rem;
+}
+
+.mission-cover__visual {
+  position: relative;
+  overflow: hidden;
+  min-height: 24rem;
+  border: 1px solid var(--hao-mission-line);
+  border-radius: calc(var(--hao-radius-lg) + 10px);
+  padding: clamp(1rem, 2.5vw, 1.4rem);
+  background:
+    radial-gradient(circle at 50% 34%, color-mix(in srgb, var(--hao-mission-accent) 18%, transparent), transparent 31%),
+    linear-gradient(135deg, color-mix(in srgb, var(--hao-surface-base) 88%, var(--hao-mission-soft)), var(--hao-surface-soft));
+  box-shadow: 0 24px 80px color-mix(in srgb, var(--hao-mission-accent) 12%, transparent);
+}
+
+.mission-cover__visual::before,
+.mission-cover__visual::after {
+  content: "";
+  position: absolute;
+  inset: 1.15rem;
+  border: 1px solid color-mix(in srgb, var(--hao-mission-accent) 22%, transparent);
+  border-radius: 50%;
+}
+
+.mission-cover__visual::after {
+  inset: 4rem 2.6rem 2.2rem 3.7rem;
+  transform: rotate(-18deg);
+  border-style: dashed;
+  opacity: 0.72;
+}
+
+.mission-orbit {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.mission-orbit span {
+  position: absolute;
+  width: 0.58rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--hao-mission-accent);
+  box-shadow: 0 0 0 0.42rem var(--hao-mission-soft);
+}
+
+.mission-orbit span:nth-child(1) {
+  top: 26%;
+  left: 28%;
+}
+
+.mission-orbit span:nth-child(2) {
+  right: 24%;
+  bottom: 33%;
+}
+
+.mission-orbit span:nth-child(3) {
+  top: 58%;
+  left: 52%;
+}
+
+.mission-cover__metadata {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 0.62rem;
+  margin: 0;
+}
+
+.mission-cover__metadata div {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.8fr) minmax(0, 1fr);
+  gap: 0.8rem;
+  border-bottom: 1px solid var(--hao-border-subtle);
+  padding-bottom: 0.62rem;
+}
+
+.mission-cover__metadata dt {
+  color: var(--hao-mission-accent);
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.mission-cover__metadata dd {
+  margin: 0;
+  color: var(--global-text-color, #111827);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-align: right;
+}
+
+.mission-cover__chips {
+  position: absolute;
+  right: 1.1rem;
+  bottom: 1.1rem;
+  left: 1.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.mission-cover__chips span {
+  border: 1px solid var(--hao-mission-line);
+  border-radius: 999px;
+  padding: 0.28rem 0.58rem;
+  background: color-mix(in srgb, var(--hao-surface-base) 72%, transparent);
+  color: var(--hao-mission-accent);
+  font-size: 0.7rem;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mission-index {
+  display: grid;
+  grid-template-columns: minmax(13rem, 0.42fr) minmax(0, 1fr);
+  gap: clamp(1rem, 3vw, 1.6rem);
+  align-items: start;
+  padding: clamp(1.1rem, 3vw, 1.5rem);
+  background: color-mix(in srgb, var(--hao-surface-base) 90%, var(--hao-mission-soft));
+}
+
+.mission-index > .mission-section-kicker,
+.mission-index > h2,
+.mission-index > p {
+  grid-column: 1;
+}
+
+.mission-index__grid {
+  grid-column: 2;
+  margin-top: 0;
+}
+
+.mission-index__item {
+  position: relative;
+  overflow: hidden;
+}
+
+.mission-index__item::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--hao-mission-line);
+}
+
+.mission-section {
+  margin-top: clamp(1.1rem, 2.5vw, 1.55rem);
+  padding: clamp(1.25rem, 3.2vw, 2rem);
+}
+
+.mission-section::before {
+  content: "";
+  position: absolute;
+  top: 1.1rem;
+  right: 1.1rem;
+  width: 3.25rem;
+  height: 1px;
+  background: var(--hao-mission-line);
+}
+
+.mission-section h2 {
+  max-width: 16ch;
+  font-size: clamp(1.55rem, 3.2vw, 2.45rem);
+  line-height: 1;
+}
+
+.mission-section__intro,
+.deployments-group__header p,
+.research-record__body p,
+.field-observation p,
+.career-phase p,
+.operations-log__body p {
+  font-size: 0.94rem;
+  line-height: 1.56;
+}
+
+.operations-log {
+  gap: 0;
+  border-left: 1px solid var(--hao-mission-line);
+  margin-left: 0.35rem;
+  padding-left: 1rem;
+}
+
+.operations-log__entry {
+  position: relative;
+  border-width: 0 0 1px;
+  border-radius: 0;
+  padding: 1rem 0;
+  background: transparent;
+}
+
+.operations-log__entry::before {
+  content: "";
+  position: absolute;
+  top: 1.25rem;
+  left: -1.27rem;
+  width: 0.5rem;
+  aspect-ratio: 1;
+  border: 2px solid var(--hao-mission-accent);
+  border-radius: 50%;
+  background: var(--hao-surface-base);
+}
+
+.operations-log__entry:last-child {
+  border-bottom: 0;
+}
+
+.deployments-grid,
+.field-observations {
+  gap: 1rem;
+}
+
+.deployments-group:first-child .deployments-grid {
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+}
+
+.deployments-group:first-child .deployment-card:first-child {
+  grid-row: span 2;
+  padding: clamp(1.1rem, 3vw, 1.45rem);
+  background:
+    radial-gradient(circle at 92% 0%, color-mix(in srgb, var(--hao-mission-accent) 16%, transparent), transparent 34%),
+    linear-gradient(135deg, color-mix(in srgb, var(--hao-surface-base) 86%, var(--hao-mission-soft)), var(--hao-surface-soft));
+}
+
+.deployments-group:first-child .deployment-card:first-child h4 {
+  font-size: clamp(1.35rem, 3vw, 1.85rem);
+  letter-spacing: -0.03em;
+}
+
+.deployment-card,
+.research-record,
+.field-observation,
+.career-phase {
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.deployment-card:hover,
+.research-record:hover,
+.field-observation:hover,
+.career-phase:hover {
+  border-color: var(--hao-mission-line);
+  box-shadow: var(--hao-shadow-card-hover);
+  transform: translateY(-1px);
+}
+
+.research-records {
+  gap: 0.9rem;
+}
+
+.research-record {
+  grid-template-columns: minmax(8rem, 0.22fr) minmax(0, 1fr);
+  background: linear-gradient(90deg, color-mix(in srgb, var(--hao-mission-accent) 5%, transparent), transparent 54%), var(--hao-surface-base);
+}
+
+.field-observations {
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+}
+
+.field-observation:first-child {
+  grid-row: span 2;
+}
+
+.career-trajectory {
+  position: relative;
+  gap: 0;
+  border-left: 1px solid var(--hao-mission-line);
+  margin-left: 0.35rem;
+  padding-left: 1rem;
+}
+
+.career-phase {
+  position: relative;
+  border-width: 0 0 1px;
+  border-radius: 0;
+  padding: 1rem 0;
+  background: transparent;
+}
+
+.career-phase::before {
+  content: "";
+  position: absolute;
+  top: 1.25rem;
+  left: -1.27rem;
+  width: 0.48rem;
+  aspect-ratio: 1;
+  border: 2px solid var(--hao-mission-accent);
+  border-radius: 50%;
+  background: var(--hao-surface-base);
+}
+
+.career-phase:last-child {
+  border-bottom: 0;
+}
+
+.mission-back-cover {
+  padding: clamp(1.7rem, 4vw, 2.45rem);
+  background:
+    radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--hao-mission-accent) 18%, transparent), transparent 35%),
+    linear-gradient(135deg, color-mix(in srgb, var(--hao-mission-accent) 6%, var(--hao-surface-base)), var(--hao-surface-soft));
+}
+
+.mission-back-cover h2 {
+  max-width: none;
+  font-size: clamp(2rem, 5vw, 3.2rem);
+}
+
+.back-cover-links a {
+  background: color-mix(in srgb, var(--hao-surface-base) 78%, transparent);
+}
+
+@media (max-width: 991px) {
+  .mission-cover__layout,
+  .mission-index {
+    grid-template-columns: 1fr;
+  }
+
+  .mission-index > .mission-section-kicker,
+  .mission-index > h2,
+  .mission-index > p,
+  .mission-index__grid {
+    grid-column: auto;
+  }
+
+  .mission-cover__visual {
+    min-height: 16rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .mission-cover {
+    min-height: auto;
+  }
+
+  .mission-cover h1 {
+    max-width: 11ch;
+    font-size: clamp(2.75rem, 17vw, 4.25rem);
+  }
+
+  .mission-cover__metadata div {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+
+  .mission-cover__metadata dd {
+    text-align: left;
+  }
+
+  .deployments-group:first-child .deployments-grid,
+  .field-observations {
+    grid-template-columns: 1fr;
+  }
+
+  .field-observation:first-child,
+  .deployments-group:first-child .deployment-card:first-child {
+    grid-row: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deployment-card,
+  .research-record,
+  .field-observation,
+  .career-phase {
+    transform: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Superseded

Closed intentionally. This PR still worked inside the existing al-folio/about-page constraints. The next Product Design reset will step outside that constrained content frame first, then rebuild the homepage as an independent full-bleed Mission Log canvas.

## Previous scope
- visual pass only
- no data/content additions
- no JavaScript

Superseded by the upcoming homepage canvas reset PR.