### PR TITLE
Repair Mission Log homepage identity and page rail (superseded by v2)

### DIFF
--- a/_plugins/mission_log_repair_pass.rb
+++ b/_plugins/mission_log_repair_pass.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module MissionLogRepairPass
+  STYLESHEET = "mission-log-repair-pass.css"
+
+  def self.homepage?(page)
+    page.relative_path == "_pages/about.md" || page.url.to_s == "/"
+  end
+
+  def self.baseurl(page)
+    page.site.config["baseurl"].to_s.sub(%r{/$}, "")
+  end
+
+  def self.inject_stylesheet(page)
+    return unless homepage?(page)
+    return unless page.output.include?("</head>")
+    return if page.output.include?(STYLESHEET)
+
+    href = "#{baseurl(page)}/assets/css/#{STYLESHEET}"
+    page.output = page.output.sub("</head>", %(<link rel="stylesheet" href="#{href}"></head>))
+  end
+
+  def self.apply_home_repairs(page)
+    return unless homepage?(page)
+
+    root = baseurl(page)
+    portrait_src = "#{root}/assets/img/blog_pic.jpg"
+
+    output = page.output
+
+    output = output.sub(
+      '<div class="mission-log-home">',
+      <<~HTML.strip
+        <div class="mission-log-home">
+          <div class="mission-identity-bar" aria-label="Site identity">
+            <a class="mission-identity-bar__name" href="#{root}/">ZHIHAO LIU</a>
+            <span class="mission-identity-bar__scope">Hao's Notes / Mission Log</span>
+          </div>
+      HTML
+    )
+
+    output = output.sub(
+      '        <div class="mission-orbit" aria-hidden="true">',
+      <<~HTML.chomp
+                <figure class="mission-cover__portrait" aria-label="Zhihao Liu portrait">
+                  <img src="#{portrait_src}" alt="Zhihao Liu" loading="eager">
+                  <figcaption>Offshore Bergen · 2020 Aug</figcaption>
+                </figure>
+                <div class="mission-orbit" aria-hidden="true">
+      HTML
+    )
+
+    output = output.sub(
+      '<h2 id="mission-index-title">Reading sequence</h2>',
+      '<h2 id="mission-index-title">Mission rail</h2>'
+    )
+
+    output = output.sub(
+      '<h2 id="current-operations-title">Active tasks and systems in motion</h2>',
+      '<h2 id="current-operations-title">Task records in motion</h2>'
+    )
+
+    output = output.sub(
+      'A task log of live, in-progress, and research systems.',
+      'A current task record for live systems, ongoing builds, and research work.'
+    )
+
+    output = output.sub(
+      '<div class="mission-section-kicker">CONTACT / BACK COVER</div>',
+      '<div class="mission-section-kicker">BACK COVER / 08</div>'
+    )
+
+    page.output = output
+  end
+end
+
+[:pages, :documents].each do |hook_owner|
+  Jekyll::Hooks.register hook_owner, :post_render do |page|
+    MissionLogRepairPass.apply_home_repairs(page)
+    MissionLogRepairPass.inject_stylesheet(page)
+  end
+end

--- a/assets/css/mission-log-repair-pass.css
+++ b/assets/css/mission-log-repair-pass.css
@@ -1,0 +1,284 @@
+/*
+ * Mission Log repair pass
+ *
+ * Product Design repair layer for the full-bleed Mission Log homepage.
+ * It restores personal identity, turns the heavy reading-sequence block
+ * into a narrow page rail, and sharpens Current Operations as task records.
+ */
+
+body:has(.mission-log-home) {
+  --mission-rail-width: 2.25rem;
+}
+
+.mission-identity-bar {
+  display: flex;
+  width: 100%;
+  max-width: var(--mission-canvas-wide);
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 auto clamp(0.85rem, 2vw, 1.4rem);
+  color: var(--global-text-color, #111827);
+}
+
+.mission-identity-bar__name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.48rem;
+  color: var(--global-text-color, #111827);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.mission-identity-bar__name::before {
+  content: "";
+  width: 0.42rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--hao-mission-accent);
+  box-shadow: 0 0 0 0.28rem var(--hao-mission-soft);
+}
+
+.mission-identity-bar__name:hover {
+  color: var(--hao-mission-accent);
+  text-decoration: none;
+}
+
+.mission-identity-bar__scope {
+  color: var(--hao-text-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.mission-cover__visual {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  align-content: stretch;
+}
+
+.mission-cover__portrait {
+  position: relative;
+  z-index: 2;
+  justify-self: end;
+  width: min(13.5rem, 58%);
+  margin: 0 0 clamp(0.9rem, 2vw, 1.25rem);
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--hao-mission-accent) 24%, var(--hao-border-subtle));
+  border-radius: clamp(0.85rem, 2vw, 1.35rem);
+  background: var(--hao-surface-base);
+  box-shadow: 0 18px 48px color-mix(in srgb, var(--hao-mission-accent) 16%, transparent);
+}
+
+.mission-cover__portrait img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  object-fit: cover;
+}
+
+.mission-cover__portrait figcaption {
+  margin: 0;
+  padding: 0.42rem 0.55rem;
+  color: var(--hao-text-muted);
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.mission-cover__metadata,
+.mission-cover__chips {
+  z-index: 2;
+}
+
+/* Convert the old Mission Index card into a very narrow page rail. */
+body:has(.mission-log-home) .mission-index {
+  position: fixed !important;
+  top: 50%;
+  left: max(0.7rem, calc((100vw - 86rem) / 2));
+  z-index: 30;
+  display: flex !important;
+  width: var(--mission-rail-width) !important;
+  max-width: var(--mission-rail-width) !important;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.92rem;
+  margin: 0 !important;
+  padding: 0.6rem 0 !important;
+  transform: translateY(-50%);
+  background: transparent !important;
+  pointer-events: auto;
+}
+
+body:has(.mission-log-home) .mission-index::before {
+  content: "00" !important;
+  display: grid !important;
+  width: 1.65rem !important;
+  height: 1.65rem !important;
+  place-items: center;
+  background: transparent !important;
+  color: var(--hao-mission-accent);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+body:has(.mission-log-home) .mission-index::after {
+  content: "" !important;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  z-index: -1;
+  width: 1px;
+  height: auto !important;
+  background: linear-gradient(180deg, transparent, var(--hao-mission-line), transparent) !important;
+  transform: translateX(-50%);
+}
+
+.mission-index > .mission-section-kicker,
+.mission-index > h2,
+.mission-index > p {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  white-space: nowrap !important;
+}
+
+body:has(.mission-log-home) .mission-index__grid {
+  display: flex !important;
+  width: 100%;
+  flex-direction: column;
+  gap: 0.85rem !important;
+  margin: 0 !important;
+}
+
+body:has(.mission-log-home) .mission-index__item {
+  display: grid !important;
+  width: 1.65rem !important;
+  height: 1.65rem !important;
+  place-items: center;
+  border: 0 !important;
+  border-radius: 50% !important;
+  padding: 0 !important;
+  background: color-mix(in srgb, var(--hao-surface-base) 84%, transparent) !important;
+  box-shadow: none !important;
+  color: var(--hao-text-muted) !important;
+  text-decoration: none !important;
+}
+
+body:has(.mission-log-home) .mission-index__item:hover {
+  background: var(--hao-mission-soft) !important;
+  color: var(--hao-mission-accent) !important;
+}
+
+body:has(.mission-log-home) .mission-index__item span,
+body:has(.mission-log-home) .mission-index__item strong {
+  display: none !important;
+}
+
+body:has(.mission-log-home) .mission-index__item::before {
+  width: auto !important;
+  background: transparent !important;
+  color: inherit;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+body:has(.mission-log-home) .mission-index__item:nth-child(1)::before {
+  content: "01";
+}
+
+body:has(.mission-log-home) .mission-index__item:nth-child(2)::before {
+  content: "02";
+}
+
+body:has(.mission-log-home) .mission-index__item:nth-child(3)::before {
+  content: "05";
+}
+
+body:has(.mission-log-home) .mission-index__item:nth-child(4)::before {
+  content: "06";
+}
+
+body:has(.mission-log-home) .mission-index__item:nth-child(5)::before {
+  content: "07";
+}
+
+body:has(.mission-log-home) .mission-index__item:nth-child(6)::before {
+  content: "08";
+}
+
+.mission-section--operations > h2 {
+  max-width: 12ch !important;
+}
+
+.mission-section--operations .operations-log__entry {
+  border-bottom-color: color-mix(in srgb, var(--hao-mission-accent) 18%, var(--hao-border-subtle));
+}
+
+.mission-back-cover .mission-section-kicker {
+  color: var(--hao-mission-accent);
+}
+
+@media (min-width: 1200px) {
+  .mission-log-home {
+    padding-left: max(var(--mission-canvas-pad), calc(var(--mission-rail-width) + 2.1rem)) !important;
+  }
+}
+
+@media (max-width: 991px) {
+  .mission-identity-bar {
+    padding-inline: 0.15rem;
+  }
+
+  body:has(.mission-log-home) .mission-index {
+    position: static !important;
+    width: 100% !important;
+    max-width: var(--mission-canvas-mid) !important;
+    flex-direction: row;
+    justify-content: center;
+    margin: clamp(1rem, 3vw, 1.5rem) auto 0 !important;
+    padding: 0 !important;
+    transform: none;
+  }
+
+  body:has(.mission-log-home) .mission-index::before,
+  body:has(.mission-log-home) .mission-index::after {
+    display: none !important;
+  }
+
+  body:has(.mission-log-home) .mission-index__grid {
+    flex-direction: row;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 767px) {
+  .mission-identity-bar {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .mission-identity-bar__scope {
+    font-size: 0.66rem;
+  }
+
+  .mission-cover__portrait {
+    width: min(11.5rem, 72%);
+    justify-self: start;
+  }
+
+  body:has(.mission-log-home) .mission-index {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Superseded by Mission Log shell reset v2

This PR was already merged, but its approach is now superseded. The merged repair plugin/CSS will be removed in the next PR because it solved the problem with post-render patches instead of a coherent homepage structure.

The v2 reset will rebuild the homepage shell directly: navbar identity, cover system, contextual rail after the hero, task-record language, section rhythm, and a cleaner final CSS layer.

No further work should continue in this PR.