### PR TITLE
Fix Mission Log v2 frontend contract

### DIFF
--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -134,15 +134,18 @@ if (!exists("assets/css/hao-design.css")) {
 const aboutPage = read("_pages/about.md");
 // prettier-ignore
 for (const requiredHomeMarker of [
+  "mission-log-home--v2",
   "COVER / 00",
-  "Small systems, field notes, and decision tools.",
-  "Recorded from the edge of climate, geospatial intelligence, and AI productivity.",
+  "A working log for systems, research, and field notes.",
+  "Recorded from the edge of climate, geospatial intelligence, and AI-native productivity.",
+  "mission-page-rail",
   "CURRENT OPERATIONS / 01",
+  "Task records in motion",
   "SELECTED DEPLOYMENTS / 02-04",
   "RESEARCH RECORD / 05",
   "FIELD OBSERVATIONS / 06",
   "CAREER TRAJECTORY / 07",
-  "CONTACT / BACK COVER",
+  "BACK COVER / 08",
   "operations-log",
 ]) {
   if (!aboutPage.includes(requiredHomeMarker)) {


### PR DESCRIPTION
## Summary
- align `test/style_contract.js` with the merged Mission Log shell v2 homepage from #61
- replace legacy homepage copy assertions with the current v2 markers
- keep the check focused on the new v2 structure: `mission-log-home--v2`, contextual `mission-page-rail`, `Task records in motion`, and `BACK COVER / 08`

## Why
#61 was merged, but its workflow failed before build/deploy because the contract still required old Mission Log copy that #61 intentionally removed. This small PR unblocks the Pages deploy without changing homepage design files.