### PR TITLE
Fix homepage safe layout after v6 regression

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -32,25 +32,23 @@ social: false
 home_cta: false
 ---
 
-<div class="hao-home hao-home--v6">
-  <section class="hao-home-hero" aria-labelledby="hao-home-title">
-    <div class="hao-home-hero__copy">
-      <p class="hao-home-kicker">Zhihao Liu · climate data · geoscience · AI tools</p>
-      <h1 id="hao-home-title">Building small data systems for climate, geoscience, and personal productivity.</h1>
-      <p class="hao-home-hero__lede">Hao's Notes is the public home for research records, shipped tools, field notes, and local-first systems. The work connects climate intelligence, geospatial evidence, offshore practice, and AI-native workflows.</p>
-      <div class="hao-home-hero__actions" aria-label="Homepage shortcuts">
-        <a class="hao-home-button hao-home-button--primary" href="#current-work">Current work</a>
-        <a class="hao-home-button" href="#systems">Systems</a>
-        <a class="hao-home-button" href="{{ '/blog/' | relative_url }}">Notes</a>
+<div class="hao-home hao-home--safe">
+  <section class="hao-safe-hero" aria-labelledby="hao-safe-title">
+    <div class="hao-safe-hero__copy">
+      <p class="hao-safe-kicker">Zhihao Liu · Climate data · Geoscience · AI tools</p>
+      <h1 id="hao-safe-title">Climate data, geoscience evidence, and small tools.</h1>
+      <p class="hao-safe-lede">Hao's Notes is the public home for research records, shipped products, field notes, and local-first systems. The work connects climate intelligence, geospatial evidence, offshore practice, and AI-native workflows.</p>
+      <div class="hao-safe-actions" aria-label="Homepage shortcuts">
+        <a class="hao-safe-button hao-safe-button--primary" href="#current-work">Current work</a>
+        <a class="hao-safe-button" href="#systems">Systems</a>
+        <a class="hao-safe-button" href="{{ '/blog/' | relative_url }}">Notes</a>
       </div>
     </div>
 
-    <aside class="hao-home-profile" aria-label="Profile summary">
-      <figure class="hao-home-profile__portrait">
-        <img src="{{ '/assets/img/blog_pic.jpg' | relative_url }}" alt="Zhihao Liu" loading="eager">
-      </figure>
-      <div class="hao-home-profile__body">
-        <p class="hao-home-profile__label">Profile</p>
+    <aside class="hao-safe-profile" aria-label="Profile summary">
+      <img src="{{ '/assets/img/blog_pic.jpg' | relative_url }}" alt="Zhihao Liu" loading="eager">
+      <div>
+        <p class="hao-safe-profile__label">Profile</p>
         <h2>Zhihao Liu</h2>
         <p>Climate & energy data scientist with a geoscience and offshore survey background.</p>
         <dl>
@@ -67,7 +65,7 @@ home_cta: false
     </aside>
   </section>
 
-  <nav class="hao-home-index" aria-label="Homepage sections">
+  <nav class="hao-safe-index" aria-label="Homepage sections">
     <a href="#current-work">Current work</a>
     <a href="#systems">Systems</a>
     <a href="#research">Research</a>
@@ -76,16 +74,16 @@ home_cta: false
     <a href="#contact">Contact</a>
   </nav>
 
-  <section class="hao-home-section hao-home-section--current" id="current-work" aria-labelledby="current-work-title">
-    <div class="hao-home-section__intro">
-      <p class="hao-home-section__kicker">Current work</p>
+  <section class="hao-safe-section" id="current-work" aria-labelledby="current-work-title">
+    <div class="hao-safe-section__intro">
+      <p class="hao-safe-kicker">Current work</p>
       <h2 id="current-work-title">Active tracks, not a news feed.</h2>
-      <p>The homepage now treats updates as maintained work lanes: active products, research engines, and public knowledge systems.</p>
+      <p>Updates are organized as maintained work lanes: public data systems, product builds, research engines, and training tools.</p>
     </div>
-    <div class="hao-home-current-grid">
+    <div class="hao-safe-card-grid hao-safe-card-grid--current">
       {% for operation in site.data.current_operations.operations %}
-        <article class="hao-home-current-card">
-          <div class="hao-home-card__meta">
+        <article class="hao-safe-card">
+          <div class="hao-safe-meta">
             <span>{{ operation.id }}</span>
             <strong>{{ operation.status }}</strong>
           </div>
@@ -99,47 +97,31 @@ home_cta: false
     </div>
   </section>
 
-  <section class="hao-home-section hao-home-section--dispatch" aria-labelledby="dispatch-title">
-    <div class="hao-home-section__intro">
-      <p class="hao-home-section__kicker">Task notes</p>
-      <h2 id="dispatch-title">Recent direction changes</h2>
+  <section class="hao-safe-section" id="systems" aria-labelledby="systems-title">
+    <div class="hao-safe-section__intro">
+      <p class="hao-safe-kicker">Selected systems</p>
+      <h2 id="systems-title">Public surfaces and working tools.</h2>
+      <p>A manually ordered view of systems that have moved beyond notes: data products, local-first tools, training apps, and research infrastructure.</p>
     </div>
-    <div class="hao-home-dispatch-list">
-      {% for dispatch in site.data.current_operations.dispatches %}
-        <article class="hao-home-dispatch">
-          <time>{{ dispatch.date }}</time>
-          <h3>{{ dispatch.label }}</h3>
-          <p>{{ dispatch.text }}</p>
-        </article>
-      {% endfor %}
-    </div>
-  </section>
-
-  <section class="hao-home-section" id="systems" aria-labelledby="systems-title">
-    <div class="hao-home-section__intro">
-      <p class="hao-home-section__kicker">Selected systems</p>
-      <h2 id="systems-title">Public surfaces and working tools</h2>
-      <p>A manually ordered view of systems that have moved beyond notes: public data products, local-first tools, training apps, and research infrastructure.</p>
-    </div>
-    <div class="hao-home-systems">
+    <div class="hao-safe-system-stack">
       {% for group in site.data.selected_deployments.groups %}
-        <section class="hao-home-system-group" aria-labelledby="hao-system-group-{{ group.id }}">
-          <div class="hao-home-group-heading">
+        <section class="hao-safe-system-group" aria-labelledby="hao-system-group-{{ group.id }}">
+          <div class="hao-safe-group-heading">
             <span>{{ group.kicker }}</span>
             <h3 id="hao-system-group-{{ group.id }}">{{ group.title }}</h3>
             <p>{{ group.summary }}</p>
           </div>
-          <div class="hao-home-system-grid">
+          <div class="hao-safe-card-grid">
             {% for deployment in group.deployments %}
-              <article class="hao-home-system-card">
-                <div class="hao-home-card__meta">
+              <article class="hao-safe-card">
+                <div class="hao-safe-meta">
                   <span>{{ deployment.ref }}</span>
                   <strong>{{ deployment.status }}</strong>
                 </div>
                 <h4>{{ deployment.title }}</h4>
-                <p class="hao-home-card__kind">{{ deployment.kind }}</p>
+                <p class="hao-safe-kind">{{ deployment.kind }}</p>
                 <p>{{ deployment.summary }}</p>
-                <div class="hao-home-card__links">
+                <div class="hao-safe-links">
                   {% if deployment.href %}
                     <a href="{{ deployment.href }}" target="_blank" rel="noopener noreferrer">{{ deployment.primary_label | default: "Open" }} →</a>
                   {% endif %}
@@ -153,29 +135,29 @@ home_cta: false
         </section>
       {% endfor %}
     </div>
-    <div class="hao-home-archive-links">
+    <div class="hao-safe-archive-links">
       <a href="{{ '/projects/' | relative_url }}">Full project archive</a>
       <a href="{{ '/repositories/' | relative_url }}">Repository archive</a>
     </div>
   </section>
 
-  <section class="hao-home-section" id="research" aria-labelledby="research-title">
-    <div class="hao-home-section__intro">
-      <p class="hao-home-section__kicker">Research record</p>
-      <h2 id="research-title">Evidence, papers, and technical artifacts</h2>
+  <section class="hao-safe-section" id="research" aria-labelledby="research-title">
+    <div class="hao-safe-section__intro">
+      <p class="hao-safe-kicker">Research record</p>
+      <h2 id="research-title">Evidence, papers, and technical artifacts.</h2>
     </div>
-    <div class="hao-home-record-list">
+    <div class="hao-safe-record-list">
       {% for record in site.data.research_records.records %}
-        <article class="hao-home-record">
-          <div class="hao-home-card__meta">
+        <article class="hao-safe-record">
+          <div class="hao-safe-meta">
             <span>{{ record.id }}</span>
             <strong>{{ record.status }}</strong>
           </div>
           <div>
             <h3>{{ record.title }}</h3>
-            <p class="hao-home-card__kind">{{ record.kind }}</p>
+            <p class="hao-safe-kind">{{ record.kind }}</p>
             <p>{{ record.summary }}</p>
-            <div class="hao-home-card__links">
+            <div class="hao-safe-links">
               {% if record.href %}
                 <a href="{{ record.href }}" target="_blank" rel="noopener noreferrer">{{ record.label | default: "Open" }} →</a>
               {% endif %}
@@ -189,16 +171,16 @@ home_cta: false
     </div>
   </section>
 
-  <section class="hao-home-section" id="notes" aria-labelledby="notes-title">
-    <div class="hao-home-section__intro">
-      <p class="hao-home-section__kicker">Field observations</p>
-      <h2 id="notes-title">Notes from the edge of the work</h2>
+  <section class="hao-safe-section" id="notes" aria-labelledby="notes-title">
+    <div class="hao-safe-section__intro">
+      <p class="hao-safe-kicker">Field observations</p>
+      <h2 id="notes-title">Notes from the edge of the work.</h2>
       <p>Selected writing that explains the systems, datasets, and AI-native workflow ideas behind the public projects.</p>
     </div>
-    <div class="hao-home-note-grid">
+    <div class="hao-safe-card-grid">
       {% for observation in site.data.field_observations.observations %}
-        <article class="hao-home-note-card">
-          <div class="hao-home-card__meta">
+        <article class="hao-safe-card">
+          <div class="hao-safe-meta">
             <span>{{ observation.id }}</span>
             <strong>{{ observation.status }}</strong>
           </div>
@@ -210,20 +192,20 @@ home_cta: false
         </article>
       {% endfor %}
     </div>
-    <div class="hao-home-archive-links">
+    <div class="hao-safe-archive-links">
       <a href="{{ '/blog/' | relative_url }}">Full notes archive</a>
     </div>
   </section>
 
-  <section class="hao-home-section hao-home-section--trajectory" id="trajectory" aria-labelledby="trajectory-title">
-    <div class="hao-home-section__intro">
-      <p class="hao-home-section__kicker">Career trajectory</p>
-      <h2 id="trajectory-title">How this path formed</h2>
+  <section class="hao-safe-section" id="trajectory" aria-labelledby="trajectory-title">
+    <div class="hao-safe-section__intro">
+      <p class="hao-safe-kicker">Career trajectory</p>
+      <h2 id="trajectory-title">How this path formed.</h2>
     </div>
-    <div class="hao-home-timeline">
+    <div class="hao-safe-timeline">
       {% for phase in site.data.career_trajectory.phases %}
-        <article class="hao-home-timeline-item">
-          <div class="hao-home-card__meta">
+        <article class="hao-safe-timeline-item">
+          <div class="hao-safe-meta">
             <span>{{ phase.id }}</span>
             <strong>{{ phase.status }}</strong>
           </div>
@@ -232,15 +214,15 @@ home_cta: false
         </article>
       {% endfor %}
     </div>
-    <div class="hao-home-archive-links">
+    <div class="hao-safe-archive-links">
       <a href="{{ '/cv/' | relative_url }}">Full CV archive</a>
     </div>
   </section>
 
-  <section class="hao-home-contact" id="contact" aria-labelledby="contact-title">
-    <p class="hao-home-section__kicker">Contact</p>
-    <h2 id="contact-title">Code, records, notes, and support</h2>
-    <div class="hao-home-contact__links">
+  <section class="hao-safe-contact" id="contact" aria-labelledby="contact-title">
+    <p class="hao-safe-kicker">Contact</p>
+    <h2 id="contact-title">Code, records, notes, and support.</h2>
+    <div class="hao-safe-contact__links">
       <a href="https://github.com/liuh886" target="_blank" rel="noopener noreferrer">GitHub</a>
       <a href="https://www.linkedin.com/in/liuzhihao" target="_blank" rel="noopener noreferrer">LinkedIn</a>
       <a href="{{ '/cv/' | relative_url }}">CV</a>

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -36,7 +36,8 @@ module SiteVisualPolish
     "mission-log-canvas-reset.css",
     "mission-log-shell-v2.css",
     "mission-log-cover-refinement.css",
-    "hao-home-v6.css"
+    "hao-home-v6.css",
+    "hao-home-safe.css"
   ].freeze
 
   def self.apply_cv_title(page)

--- a/assets/css/hao-home-safe.css
+++ b/assets/css/hao-home-safe.css
@@ -1,0 +1,494 @@
+/*
+ * Hao home safe layout
+ *
+ * Conservative production layer after the failed Mission Log/v6 experiments.
+ * The goal is legibility first: no duplicated about header, no giant clipped
+ * headline, no fixed rail, no full-bleed canvas, and no horizontal overflow.
+ */
+
+body:has(.hao-home--safe) {
+  --hao-safe-width: min(100% - 2rem, 68rem);
+  --hao-safe-ink: var(--global-text-color, #111827);
+  --hao-safe-muted: var(--hao-text-muted, #6b7280);
+  --hao-safe-surface: var(--hao-surface-base, #ffffff);
+  --hao-safe-soft: color-mix(in srgb, var(--hao-mission-accent, #b80fb8) 5%, var(--hao-surface-base, #ffffff));
+  --hao-safe-line: color-mix(in srgb, var(--hao-mission-accent, #b80fb8) 14%, var(--hao-border-subtle, #e5e7eb));
+  overflow-x: clip;
+}
+
+html:has(.hao-home--safe) {
+  overflow-x: clip;
+}
+
+/* Hide the al-folio about layout header/profile so the custom homepage is not duplicated. */
+body:has(.hao-home--safe) .post > header,
+body:has(.hao-home--safe) .post-title,
+body:has(.hao-home--safe) .post-description,
+body:has(.hao-home--safe) .profile {
+  display: none !important;
+}
+
+body:has(.hao-home--safe) .post {
+  width: 100% !important;
+  max-width: none !important;
+  padding-top: 0 !important;
+}
+
+body:has(.hao-home--safe) main,
+body:has(.hao-home--safe) main > .container,
+body:has(.hao-home--safe) .container:has(.hao-home--safe) {
+  width: 100% !important;
+  max-width: none !important;
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+}
+
+body:has(.hao-home--safe) .navbar .container,
+body:has(.hao-home--safe) .navbar .container-fluid {
+  width: var(--hao-safe-width) !important;
+  max-width: var(--hao-safe-width) !important;
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+}
+
+.hao-home--safe {
+  box-sizing: border-box;
+  width: var(--hao-safe-width);
+  max-width: var(--hao-safe-width);
+  margin: 0 auto;
+  padding: clamp(3.5rem, 7vw, 5rem) 0 clamp(3rem, 7vw, 5rem);
+  color: var(--hao-safe-ink);
+}
+
+.hao-home--safe *,
+.hao-home--safe *::before,
+.hao-home--safe *::after {
+  box-sizing: border-box;
+}
+
+.hao-home--safe a {
+  color: var(--hao-mission-accent, #b80fb8);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.hao-home--safe a:hover,
+.hao-home--safe a:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.hao-safe-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 20rem);
+  gap: clamp(2rem, 6vw, 4.5rem);
+  align-items: center;
+  padding-bottom: clamp(2rem, 5vw, 3.5rem);
+  border-bottom: 1px solid var(--hao-safe-line);
+}
+
+.hao-safe-kicker,
+.hao-safe-profile__label,
+.hao-safe-group-heading span {
+  margin: 0 0 0.75rem;
+  color: var(--hao-mission-accent, #b80fb8);
+  font-size: 0.72rem;
+  font-weight: 820;
+  letter-spacing: 0.13em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.hao-safe-hero h1 {
+  max-width: 11.5em;
+  margin: 0;
+  color: var(--hao-safe-ink);
+  font-size: clamp(2.4rem, 5vw, 4.25rem);
+  letter-spacing: -0.055em;
+  line-height: 1.02;
+  text-wrap: balance;
+}
+
+.hao-safe-lede {
+  max-width: 42rem;
+  margin: 1.15rem 0 0;
+  color: color-mix(in srgb, var(--hao-safe-ink) 76%, var(--hao-safe-muted));
+  font-size: clamp(1rem, 1.5vw, 1.16rem);
+  line-height: 1.68;
+}
+
+.hao-safe-actions,
+.hao-safe-links,
+.hao-safe-archive-links,
+.hao-safe-contact__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.hao-safe-actions {
+  margin-top: 1.5rem;
+}
+
+.hao-safe-button,
+.hao-safe-archive-links a,
+.hao-safe-contact__links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.55rem;
+  border: 1px solid var(--hao-safe-line);
+  border-radius: 999px;
+  padding: 0.65rem 1rem;
+  background: var(--hao-safe-surface);
+  color: var(--hao-safe-ink) !important;
+  font-size: 0.84rem;
+  font-weight: 720;
+  text-decoration: none !important;
+}
+
+.hao-safe-button--primary {
+  border-color: var(--hao-mission-accent, #b80fb8);
+  background: var(--hao-mission-accent, #b80fb8);
+  color: #ffffff !important;
+}
+
+.hao-safe-profile {
+  display: grid;
+  grid-template-columns: 7rem minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+  border: 1px solid var(--hao-safe-line);
+  border-radius: 1.25rem;
+  padding: 1rem;
+  background: linear-gradient(180deg, var(--hao-safe-surface), var(--hao-safe-soft));
+}
+
+.hao-safe-profile img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  border: 1px solid var(--hao-safe-line);
+  border-radius: 1rem;
+  object-fit: cover;
+}
+
+.hao-safe-profile h2 {
+  margin: 0;
+  color: var(--hao-safe-ink);
+  font-size: 1.1rem;
+  line-height: 1.22;
+  letter-spacing: -0.02em;
+}
+
+.hao-safe-profile p:not(.hao-safe-profile__label) {
+  margin: 0.45rem 0 0;
+  color: var(--hao-safe-muted);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.hao-safe-profile dl {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0.8rem 0 0;
+}
+
+.hao-safe-profile dl div {
+  display: grid;
+  grid-template-columns: 3.4rem minmax(0, 1fr);
+  gap: 0.65rem;
+}
+
+.hao-safe-profile dt,
+.hao-safe-profile dd {
+  margin: 0;
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.hao-safe-profile dt {
+  color: var(--hao-safe-muted);
+  font-weight: 760;
+  text-transform: uppercase;
+}
+
+.hao-safe-profile dd {
+  color: var(--hao-safe-ink);
+  font-weight: 720;
+}
+
+.hao-safe-index {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin: 1rem 0 0;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid var(--hao-safe-line);
+}
+
+.hao-safe-index a {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.36rem 0.6rem;
+  color: var(--hao-safe-muted);
+  font-size: 0.76rem;
+  font-weight: 740;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hao-safe-index a:hover,
+.hao-safe-index a:focus-visible {
+  border-color: var(--hao-safe-line);
+  color: var(--hao-mission-accent, #b80fb8);
+  text-decoration: none;
+}
+
+.hao-safe-section,
+.hao-safe-contact {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.34fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 5vw, 3.5rem);
+  padding: clamp(2.75rem, 6vw, 4.25rem) 0;
+  border-bottom: 1px solid var(--hao-safe-line);
+  scroll-margin-top: 5rem;
+}
+
+.hao-safe-section__intro h2,
+.hao-safe-contact h2 {
+  max-width: 12em;
+  margin: 0;
+  color: var(--hao-safe-ink);
+  font-size: clamp(1.65rem, 3.2vw, 2.45rem);
+  letter-spacing: -0.045em;
+  line-height: 1.05;
+  text-wrap: balance;
+}
+
+.hao-safe-section__intro p:not(.hao-safe-kicker),
+.hao-safe-contact p:not(.hao-safe-kicker) {
+  margin: 0.85rem 0 0;
+  color: var(--hao-safe-muted);
+  font-size: 0.95rem;
+  line-height: 1.62;
+}
+
+.hao-safe-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.hao-safe-card,
+.hao-safe-record,
+.hao-safe-timeline-item {
+  min-width: 0;
+  border: 1px solid var(--hao-safe-line);
+  border-radius: 1.1rem;
+  padding: 1rem;
+  background: var(--hao-safe-surface);
+}
+
+.hao-safe-card-grid--current .hao-safe-card:first-child,
+.hao-safe-system-group:first-child .hao-safe-card:first-child {
+  background: linear-gradient(180deg, var(--hao-safe-soft), var(--hao-safe-surface));
+}
+
+.hao-safe-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.8rem;
+  color: var(--hao-safe-muted);
+  font-size: 0.68rem;
+  font-weight: 780;
+  letter-spacing: 0.08em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.hao-safe-meta strong {
+  color: var(--hao-mission-accent, #b80fb8);
+}
+
+.hao-safe-card h3,
+.hao-safe-card h4,
+.hao-safe-record h3,
+.hao-safe-timeline-item h3 {
+  margin: 0;
+  color: var(--hao-safe-ink);
+  font-size: 1.05rem;
+  letter-spacing: -0.025em;
+  line-height: 1.24;
+}
+
+.hao-safe-card p,
+.hao-safe-record p,
+.hao-safe-timeline-item p {
+  margin: 0.65rem 0 0;
+  color: var(--hao-safe-muted);
+  font-size: 0.9rem;
+  line-height: 1.58;
+}
+
+.hao-safe-card > a {
+  display: inline-flex;
+  margin-top: 0.85rem;
+}
+
+.hao-safe-system-stack {
+  display: grid;
+  gap: clamp(1.6rem, 4vw, 2.5rem);
+}
+
+.hao-safe-system-group {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.hao-safe-group-heading {
+  max-width: 42rem;
+}
+
+.hao-safe-group-heading h3 {
+  margin: 0;
+  color: var(--hao-safe-ink);
+  font-size: 1.3rem;
+  letter-spacing: -0.035em;
+}
+
+.hao-safe-group-heading p {
+  margin: 0.5rem 0 0;
+  color: var(--hao-safe-muted);
+  font-size: 0.93rem;
+  line-height: 1.56;
+}
+
+.hao-safe-kind {
+  color: color-mix(in srgb, var(--hao-safe-ink) 68%, var(--hao-safe-muted)) !important;
+  font-weight: 720;
+}
+
+.hao-safe-links,
+.hao-safe-archive-links {
+  margin-top: 0.85rem;
+}
+
+.hao-safe-record-list,
+.hao-safe-timeline {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.hao-safe-record {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.25fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.hao-safe-timeline {
+  position: relative;
+  padding-left: 1rem;
+}
+
+.hao-safe-timeline::before {
+  content: "";
+  position: absolute;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  left: 0;
+  width: 1px;
+  background: var(--hao-safe-line);
+}
+
+.hao-safe-timeline-item {
+  position: relative;
+}
+
+.hao-safe-timeline-item::before {
+  content: "";
+  position: absolute;
+  top: 1.15rem;
+  left: -1.28rem;
+  width: 0.48rem;
+  aspect-ratio: 1;
+  border: 2px solid var(--hao-safe-surface);
+  border-radius: 50%;
+  background: var(--hao-mission-accent, #b80fb8);
+}
+
+.hao-safe-contact {
+  border-bottom: 0;
+}
+
+.hao-safe-contact__links {
+  align-content: start;
+}
+
+html[data-theme="dark"] body:has(.hao-home--safe) {
+  --hao-safe-soft: color-mix(in srgb, var(--hao-mission-accent, #b80fb8) 11%, var(--hao-surface-base, #111827));
+}
+
+@media (max-width: 900px) {
+  .hao-home--safe {
+    padding-top: 2.5rem;
+  }
+
+  .hao-safe-hero,
+  .hao-safe-section,
+  .hao-safe-contact {
+    grid-template-columns: 1fr;
+  }
+
+  .hao-safe-hero {
+    align-items: start;
+  }
+
+  .hao-safe-profile {
+    max-width: 30rem;
+  }
+
+  .hao-safe-section__intro h2,
+  .hao-safe-contact h2 {
+    max-width: 16em;
+  }
+}
+
+@media (max-width: 680px) {
+  body:has(.hao-home--safe) {
+    --hao-safe-width: min(100% - 1.25rem, 68rem);
+  }
+
+  .hao-safe-hero h1 {
+    font-size: clamp(2.15rem, 11vw, 3.35rem);
+    letter-spacing: -0.05em;
+  }
+
+  .hao-safe-card-grid,
+  .hao-safe-record {
+    grid-template-columns: 1fr;
+  }
+
+  .hao-safe-profile {
+    grid-template-columns: 5.5rem minmax(0, 1fr);
+    gap: 0.85rem;
+    padding: 0.85rem;
+  }
+
+  .hao-safe-index {
+    gap: 0.35rem;
+  }
+
+  .hao-safe-index a {
+    font-size: 0.7rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body:has(.hao-home--safe) {
+    scroll-behavior: auto;
+  }
+}

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -2,10 +2,8 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const root = process.cwd();
-
 const read = (relPath) => fs.readFileSync(path.join(root, relPath), "utf8");
 const exists = (relPath) => fs.existsSync(path.join(root, relPath));
-const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const failures = [];
 
@@ -26,290 +24,98 @@ const requireAbsent = (source, values, label) => {
 };
 
 const requireRegex = (source, regex, message) => {
-  if (!regex.test(source)) {
-    failures.push(message);
-  }
+  if (!regex.test(source)) failures.push(message);
 };
 
 const packageJson = JSON.parse(read("package.json"));
 const scripts = packageJson.scripts || {};
-const forbiddenScripts = [
-  "build:css",
-  "build:tailwind",
-  "build:tailwind:watch",
-];
-
-for (const forbiddenScript of forbiddenScripts) {
+for (const forbiddenScript of ["build:css", "build:tailwind", "build:tailwind:watch"]) {
   if (Object.prototype.hasOwnProperty.call(scripts, forbiddenScript)) {
-    failures.push(
-      `Starter package.json must not define \`${forbiddenScript}\`; ` +
-        "build ownership belongs to gem repos.",
-    );
+    failures.push(`Starter package.json must not define \`${forbiddenScript}\`; build ownership belongs to gem repos.`);
   }
 }
 
 const config = read("_config.yml");
-requireRegex(
-  config,
-  /^\s*theme:\s*al_folio_core\s*$/m,
-  "`_config.yml` must keep `theme: al_folio_core` for thin-starter wiring.",
-);
-
-for (const pluginName of [
-  "al_folio_core",
-  "al_folio_distill",
-  "al_cookie",
-  "al_icons",
-  "al_math",
-]) {
-  requireRegex(
-    config,
-    new RegExp(`^\\s*-\\s*${escapeRegExp(pluginName)}\\s*$`, "m"),
-    `\`_config.yml\` plugins must include \`${pluginName}\`.`,
-  );
-}
-
-for (const libraryKey of ["fontawesome", "academicons", "scholar-icons"]) {
-  const hasLibrary = new RegExp(
-    `^\\s{2}${escapeRegExp(libraryKey)}:\\s*$`,
-    "m",
-  ).test(config);
-
-  if (!hasLibrary) {
-    failures.push(
-      `\`_config.yml\` must define ` +
-        `\`third_party_libraries.${libraryKey}\` for al_icons runtime wiring.`,
-    );
-    continue;
-  }
-
-  const hasIntegrity = new RegExp(
-    `^\\s{2}${escapeRegExp(libraryKey)}:[\\s\\S]*?` +
-      "^\\s{4}integrity:\\s*$[\\s\\S]*?^\\s{6}css:\\s*\"sha",
-    "m",
-  ).test(config);
-
-  if (!hasIntegrity) {
-    failures.push(
-      `\`_config.yml\` should define an SRI hash for ` +
-        `\`third_party_libraries.${libraryKey}.integrity.css\`.`,
-    );
-  }
-}
-
-for (const libraryKey of ["tikzjax", "tocbot"]) {
-  requireRegex(
-    config,
-    new RegExp(`^\\s{2}${escapeRegExp(libraryKey)}:\\s*$`, "m"),
-    `\`_config.yml\` must define ` +
-      `\`third_party_libraries.${libraryKey}\` for v1 runtime contracts.`,
-  );
+requireRegex(config, /^\s*theme:\s*al_folio_core\s*$/m, "`_config.yml` must keep `theme: al_folio_core` for thin-starter wiring.");
+for (const pluginName of ["al_folio_core", "al_folio_distill", "al_cookie", "al_icons", "al_math"]) {
+  requireRegex(config, new RegExp(`^\\s*-\\s*${pluginName}\\s*$`, "m"), `\`_config.yml\` plugins must include \`${pluginName}\`.`);
 }
 
 const gemfile = read("Gemfile");
-requireRegex(
-  gemfile,
-  /gem 'al_math', '= 1\.0\.1'/,
-  "`Gemfile` should pin `al_math` to released version `1.0.1`.",
-);
-
+requireRegex(gemfile, /gem 'al_math', '= 1\.0\.1'/, "`Gemfile` should pin `al_math` to released version `1.0.1`.");
 if (/gem 'al_math',\s*:git =>/.test(gemfile)) {
-  failures.push(
-    "`Gemfile` must not use git-branch pin for `al_math`; " +
-      "use released gem version.",
-  );
+  failures.push("`Gemfile` must not use git-branch pin for `al_math`; use released gem version.");
 }
 
-for (const forbiddenPath of [
-  "_includes",
-  "_layouts",
-  "_sass",
-  "_scripts",
-  "assets/tailwind",
-  "tailwind.config.js",
-  "assets/webfonts",
-]) {
+for (const forbiddenPath of ["_includes", "_layouts", "_sass", "_scripts", "assets/tailwind", "tailwind.config.js", "assets/webfonts"]) {
   if (exists(forbiddenPath)) {
-    failures.push(
-      `Starter must not own core component path \`${forbiddenPath}\`; ` +
-        "move ownership to the corresponding gem.",
-    );
+    failures.push(`Starter must not own core component path \`${forbiddenPath}\`; move ownership to the corresponding gem.`);
   }
 }
 
-for (const forbiddenGlobPath of [
-  "assets/fonts/academicons.woff",
-  "assets/fonts/academicons.ttf",
-  "assets/fonts/scholar-icons.woff",
-  "assets/fonts/scholar-icons.ttf",
-]) {
-  if (exists(forbiddenGlobPath)) {
-    failures.push(
-      `Starter must not own icon runtime artifact ` +
-        `\`${forbiddenGlobPath}\`; icon ownership belongs to al_icons.`,
-    );
-  }
-}
-
-for (const requiredPath of [
-  "test/visual",
-  "test/integration_plugin_toggles.sh",
-  "test/integration_distill.sh",
-]) {
-  if (!exists(requiredPath)) {
-    failures.push(
-      `Starter integration/visual contract missing required path: ` +
-        `\`${requiredPath}\`.`,
-    );
-  }
+for (const requiredPath of ["test/visual", "test/integration_plugin_toggles.sh", "test/integration_distill.sh"]) {
+  if (!exists(requiredPath)) failures.push(`Starter integration/visual contract missing required path: \`${requiredPath}\`.`);
 }
 
 const visualPlugin = read("_plugins/site_visual_polish.rb");
-requireIncludes(
-  visualPlugin,
-  ["site-polish.css", "site-upgrade.css", "hao-design.css", "hao-home-v6.css"],
-  "Site visual polish plugin",
-);
+requireIncludes(visualPlugin, ["site-polish.css", "site-upgrade.css", "hao-design.css", "hao-home-safe.css"], "Site visual polish plugin");
+requireRegex(visualPlugin, /"hao-home-v6\.css",\s*"hao-home-safe\.css"/m, "Safe homepage stylesheet must load after v6 so it can override the failed layout.");
 
-if (!exists("assets/css/site-upgrade.css")) {
-  failures.push("Frontend upgrade layer missing: `assets/css/site-upgrade.css`.");
-} else {
-  const upgradeCss = read("assets/css/site-upgrade.css");
-  requireIncludes(
-    upgradeCss,
-    [
-      "article:has(.header-bar) .post-list",
-      "article:has(.header-bar) .featured-posts .row",
-      "body:has(.cv) .sticky-top::-webkit-scrollbar",
-      "content-visibility: auto",
-      "prefers-reduced-motion",
-    ],
-    "Frontend upgrade CSS",
-  );
-}
+if (!exists("assets/css/site-upgrade.css")) failures.push("Frontend upgrade layer missing: `assets/css/site-upgrade.css`.");
+if (!exists("assets/css/hao-design.css")) failures.push("Hao design system layer missing: `assets/css/hao-design.css`.");
+if (!exists("assets/css/hao-home-safe.css")) failures.push("Safe homepage CSS missing: `assets/css/hao-home-safe.css`.");
 
-if (!exists("assets/css/hao-design.css")) {
-  failures.push("Hao design system layer missing: `assets/css/hao-design.css`.");
-} else {
-  const haoDesignCss = read("assets/css/hao-design.css");
-  requireIncludes(
-    haoDesignCss,
-    [
-      "--hao-page-max",
-      "--hao-reading-max",
-      "--hao-focus-ring",
-      "--hao-mission-accent",
-      ".mission-log-home",
-      ".mission-section-kicker",
-      ".mission-index__grid",
-      ".operations-log__entry",
-      "body:has(.cv) .sticky-top::-webkit-scrollbar",
-      "scrollbar-width: none",
-      "prefers-reduced-motion",
-    ],
-    "Hao design CSS",
-  );
-}
-
-if (!exists("assets/css/hao-home-v6.css")) {
-  failures.push("Clean homepage reframe CSS missing: `assets/css/hao-home-v6.css`.");
-} else {
-  const homeCss = read("assets/css/hao-home-v6.css");
-  requireIncludes(
-    homeCss,
-    [
-      ".hao-home--v6",
-      ".hao-home-hero",
-      ".hao-home-index",
-      ".hao-home-current-grid",
-      ".hao-home-system-grid",
-      "overflow-x: clip",
-      "prefers-reduced-motion",
-    ],
-    "Homepage v6 CSS",
-  );
-}
+const homeSafeCss = exists("assets/css/hao-home-safe.css") ? read("assets/css/hao-home-safe.css") : "";
+requireIncludes(homeSafeCss, [
+  ".hao-home--safe",
+  "body:has(.hao-home--safe) .post-title",
+  "body:has(.hao-home--safe) .profile",
+  "overflow-x: clip",
+  "font-size: clamp(2.4rem, 5vw, 4.25rem)",
+  "grid-template-columns: minmax(0, 1fr) minmax(18rem, 20rem)",
+  "@media (max-width: 900px)",
+  "@media (max-width: 680px)",
+  "prefers-reduced-motion",
+], "Safe homepage CSS");
+requireAbsent(homeSafeCss, ["position: fixed", "min-height: 100vh", "100vw"], "Safe homepage CSS");
 
 const aboutPage = read("_pages/about.md");
-requireIncludes(
-  aboutPage,
-  [
-    "hao-home--v6",
-    "Building small data systems for climate, geoscience, and personal productivity.",
-    "Current work",
-    "Active tracks, not a news feed.",
-    "hao-home-current-grid",
-    "Task notes",
-    "Selected systems",
-    "Research record",
-    "Field observations",
-    "Career trajectory",
-    "hao-home-contact",
-  ],
-  "Hao homepage v6",
-);
-
-requireAbsent(
-  aboutPage,
-  ["mission-log-home--product", "mission-page-rail", "operations-console"],
-  "Hao homepage v6",
-);
-
-requireRegex(
-  aboutPage,
-  /^news:\s*false\b/m,
-  "Hao homepage must keep legacy `news` disabled.",
-);
-
-requireRegex(
-  aboutPage,
-  /^\s*enabled:\s*false\b/m,
-  "Hao homepage must keep legacy announcements disabled.",
-);
+requireIncludes(aboutPage, [
+  "hao-home--safe",
+  "Climate data, geoscience evidence, and small tools.",
+  "Current work",
+  "Active tracks, not a news feed.",
+  "Selected systems",
+  "Research record",
+  "Field observations",
+  "Career trajectory",
+  "hao-safe-contact",
+], "Safe homepage");
+requireAbsent(aboutPage, [
+  "hao-home--v6",
+  "Building small data systems for climate, geoscience, and personal productivity.",
+  "mission-log-home--product",
+  "mission-page-rail",
+  "operations-console",
+], "Safe homepage");
+requireRegex(aboutPage, /^news:\s*false\b/m, "Hao homepage must keep legacy `news` disabled.");
+requireRegex(aboutPage, /^\s*enabled:\s*false\b/m, "Hao homepage must keep legacy announcements disabled.");
 
 if (!exists("_data/current_operations.yml")) {
   failures.push("Current operations data missing: `_data/current_operations.yml`.");
 } else {
   const currentOperations = read("_data/current_operations.yml");
-  requireIncludes(
-    currentOperations,
-    [
-      "OP-01",
-      "CCUS Policy Hub",
-      "Ownly",
-      "FlappyK",
-      "RhythmCoach",
-      "AlphaEngine",
-      "dispatches",
-      "Shell reset",
-    ],
-    "Current operations log",
-  );
+  requireIncludes(currentOperations, ["OP-01", "CCUS Policy Hub", "Ownly", "FlappyK", "RhythmCoach", "AlphaEngine"], "Current operations log");
 }
 
-for (const hiddenNavPage of [
-  "_pages/projects.md",
-  "_pages/repositories.md",
-  "cv.md",
-]) {
+for (const hiddenNavPage of ["_pages/projects.md", "_pages/repositories.md", "cv.md"]) {
   if (!/^nav:\s*false$/m.test(read(hiddenNavPage))) {
-    failures.push(
-      `Hao homepage nav strategy requires \`${hiddenNavPage}\` ` +
-        "to keep `nav: false`.",
-    );
+    failures.push(`Hao homepage nav strategy requires \`${hiddenNavPage}\` to keep \`nav: false\`.`);
   }
 }
 
-for (const requiredDoc of [
-  "docs/DESIGN_SYSTEM.md",
-  "docs/REDESIGN_ROADMAP.md",
-  "docs/MISSION_LOG_PLAN.md",
-]) {
-  if (!exists(requiredDoc)) {
-    failures.push(
-      `Hao redesign documentation missing required path: \`${requiredDoc}\`.`,
-    );
-  }
+for (const requiredDoc of ["docs/DESIGN_SYSTEM.md", "docs/REDESIGN_ROADMAP.md", "docs/MISSION_LOG_PLAN.md"]) {
+  if (!exists(requiredDoc)) failures.push(`Hao redesign documentation missing required path: \`${requiredDoc}\`.`);
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Summary
- replace the unstable v6 homepage root with a conservative `hao-home--safe` structure
- stop inheriting the failed v6 giant-headline layout and add a dedicated safe stylesheet loaded last
- hide the default al-folio about title/profile so the homepage does not render twice
- constrain hero typography, profile card width, section grids, and horizontal overflow for production safety
- update frontend contracts to require the safe layout and reject the failed v6/Mission Log markers

## Product Design intent
The live screenshots show this was not a small spacing issue. The page was rendering both the theme's default about header/profile and a custom homepage, while the v6 hero typography was too aggressive for common desktop viewports. This PR intentionally returns to a calmer, readable personal product homepage before any further visual ambition.

## Verification required before merge
- frontend contract must pass
- Jekyll production build must pass
- PurgeCSS must pass
- no direct merge until CI is green on this PR head