### PR TITLE
Bust visual stylesheet cache

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -41,6 +41,10 @@ module SiteVisualPolish
     "hao-home-center-fix.css"
   ].freeze
 
+  # Bump this value whenever the final visual layer changes. GitHub Pages and
+  # browsers may otherwise keep serving an older CSS response for the same path.
+  STYLESHEET_VERSION = "20260802-superdesign-rescue".freeze
+
   def self.apply_cv_title(page)
     return unless page.relative_path == "cv.md"
 
@@ -67,7 +71,7 @@ module SiteVisualPolish
     STYLESHEETS.each do |stylesheet|
       next if page.output.include?(stylesheet)
 
-      href = "#{baseurl}/assets/css/#{stylesheet}"
+      href = "#{baseurl}/assets/css/#{stylesheet}?v=#{STYLESHEET_VERSION}"
       tag = %(<link rel="stylesheet" href="#{href}">)
       page.output = page.output.sub("</head>", "#{tag}</head>")
     end


### PR DESCRIPTION
## Summary
- append a build version query string to all visual stylesheet links injected by the Jekyll polish plugin
- force browsers and GitHub Pages edge caches to load the latest Superdesign homepage CSS
- no homepage content or visual rules changed

## Verification
- frontend contract should pass
- production build should pass
- PurgeCSS should pass
- after deploy, hard-refresh homepage and confirm updated navbar/homepage CSS is loaded with `?v=20260802-superdesign-rescue`