### PR TITLE
Restore al-folio visual baseline with homepage-only enhancement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,12 +78,11 @@ jobs:
         run: |
           set -euo pipefail
           test -f _site/index.html
-          grep -q 'hao-home--safe' _site/index.html
-          grep -q 'hao-home--production' _site/index.html
-          grep -q 'Build systems that turn field evidence into usable products.' _site/index.html
-          grep -q 'hao-home-center-fix.css?v=20260802-shell-navbar-fix' _site/index.html
+          grep -q 'hao-home--alfolio' _site/index.html
+          grep -q 'Research records, shipped tools, and field-informed systems.' _site/index.html
+          grep -q 'hao-home-center-fix.css?v=20260802-alfolio-wide-home' _site/index.html
           grep -q 'hao-home-navbar-brand' _site/index.html
-          grep -q 'Zhihao LIU' _site/index.html
+          grep -q 'font-weight-bold">Zhihao</span> LIU' _site/index.html
           if grep -q 'mission-log-shell-v2.css' _site/index.html; then
             echo "Deprecated Mission Log stylesheet leaked into homepage artifact."
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
           test -f _site/index.html
           grep -q 'hao-home--alfolio' _site/index.html
           grep -q 'Research records, shipped tools, and field-informed systems.' _site/index.html
-          grep -q 'hao-home-center-fix.css?v=20260802-alfolio-wide-home' _site/index.html
+          grep -q 'hao-home-center-fix.css?v=20260802-alfolio-baseline' _site/index.html
           grep -q 'hao-home-navbar-brand' _site/index.html
           grep -q 'font-weight-bold">Zhihao</span> LIU' _site/index.html
           if grep -q 'mission-log-shell-v2.css' _site/index.html; then
@@ -89,6 +89,15 @@ jobs:
           fi
           if grep -q 'hao-home-v6.css' _site/index.html; then
             echo "Deprecated v6 stylesheet leaked into homepage artifact."
+            exit 1
+          fi
+
+      - name: Verify secondary pages keep al-folio baseline 🔎
+        run: |
+          set -euo pipefail
+          test -f _site/blog/index.html
+          if grep -Eq 'site-polish.css|site-upgrade.css|hao-design.css|hao-home-safe.css|hao-home-center-fix.css' _site/blog/index.html; then
+            echo "Custom visual stylesheet leaked into blog index; secondary pages should keep the al-folio baseline."
             exit 1
           fi
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -32,47 +32,20 @@ social: false
 home_cta: false
 ---
 
-<div class="hao-home hao-home--safe hao-home--production">
-  <section class="hao-prod-hero" aria-labelledby="hao-prod-title">
-    <div class="hao-prod-hero__content">
-      <p class="hao-prod-eyebrow">Independent Builder · Climate · Geospatial · AI</p>
-      <h1 id="hao-prod-title">Build systems that turn field evidence into usable products.</h1>
-      <p class="hao-prod-lede">Hao's Notes is the public surface for my climate data work, geoscience evidence, shipped tools, and local-first systems. It connects offshore practice, geospatial intelligence, AI-native workflows, and product experiments into one working record.</p>
-      <div class="hao-prod-actions" aria-label="Homepage shortcuts">
-        <a class="hao-prod-button hao-prod-button--primary" href="#current-work">Explore current work</a>
-        <a class="hao-prod-button" href="#systems">View systems</a>
-        <a class="hao-prod-button" href="{{ '/blog/' | relative_url }}">Read notes</a>
-      </div>
+<div class="hao-home hao-home--production hao-home--alfolio">
+  <section class="hao-home-intro" aria-labelledby="hao-home-intro-title">
+    <p class="hao-home-eyebrow">Climate data · Geoscience evidence · AI tools</p>
+    <h2 id="hao-home-intro-title">Research records, shipped tools, and field-informed systems.</h2>
+    <p>Hao's Notes is the public surface for my climate data work, geoscience evidence, shipped tools, and local-first systems. It keeps the original al-folio homepage structure, while giving the active work a wider and more organized presentation.</p>
+    <div class="hao-home-actions" aria-label="Homepage shortcuts">
+      <a class="hao-home-button hao-home-button--primary" href="#current-work">Current work</a>
+      <a class="hao-home-button" href="#systems">Systems</a>
+      <a class="hao-home-button" href="#knowledge">Knowledge</a>
+      <a class="hao-home-button" href="{{ '/blog/' | relative_url }}">Notes</a>
     </div>
-
-    <aside class="hao-prod-profile" aria-label="Profile summary">
-      <div class="hao-prod-profile__glow" aria-hidden="true"></div>
-      <figure class="hao-prod-profile__portrait">
-        <img src="{{ '/assets/img/blog_pic.jpg' | relative_url }}" alt="Zhihao Liu" loading="eager">
-      </figure>
-      <div class="hao-prod-profile__body">
-        <p class="hao-prod-card-label">Profile</p>
-        <h2>Zhihao Liu</h2>
-        <p>Climate & energy data scientist with a geoscience and offshore survey background.</p>
-        <dl class="hao-prod-profile__facts">
-          <div>
-            <dt>Focus</dt>
-            <dd>Climate · Geo · AI</dd>
-          </div>
-          <div>
-            <dt>Mode</dt>
-            <dd>Research · Build · Record</dd>
-          </div>
-          <div>
-            <dt>Surface</dt>
-            <dd>Products · Notes · Data</dd>
-          </div>
-        </dl>
-      </div>
-    </aside>
   </section>
 
-  <nav class="hao-prod-index" aria-label="Homepage sections">
+  <nav class="hao-home-index" aria-label="Homepage sections">
     <a href="#current-work">Current work</a>
     <a href="#systems">Systems</a>
     <a href="#knowledge">Knowledge</a>
@@ -80,60 +53,60 @@ home_cta: false
     <a href="#contact">Contact</a>
   </nav>
 
-  <section class="hao-prod-section hao-prod-section--current" id="current-work" aria-labelledby="current-work-title">
-    <div class="hao-prod-section__header">
-      <p class="hao-prod-eyebrow">Current work</p>
+  <section class="hao-home-section" id="current-work" aria-labelledby="current-work-title">
+    <div class="hao-home-section-header">
+      <p class="hao-home-eyebrow">Current work</p>
       <h2 id="current-work-title">Active tracks, organized as working lanes.</h2>
       <p>Updates are organized as maintained work lanes: public data systems, product builds, research engines, and training tools.</p>
     </div>
-    <div class="hao-prod-work-grid">
+    <div class="hao-home-card-grid">
       {% for operation in site.data.current_operations.operations %}
-        <article class="hao-prod-card hao-prod-card--work">
-          <div class="hao-prod-card__topline">
+        <article class="hao-home-card">
+          <div class="hao-home-card-topline">
             <span>{{ operation.id }}</span>
             <strong>{{ operation.status }}</strong>
           </div>
           <h3>{{ operation.title }}</h3>
           <p>{{ operation.summary }}</p>
           {% if operation.href %}
-            <a class="hao-prod-text-link" href="{{ operation.href }}" target="_blank" rel="noopener noreferrer">{{ operation.label | default: "Open" }} →</a>
+            <a class="hao-home-text-link" href="{{ operation.href }}" target="_blank" rel="noopener noreferrer">{{ operation.label | default: "Open" }} →</a>
           {% endif %}
         </article>
       {% endfor %}
     </div>
   </section>
 
-  <section class="hao-prod-section hao-prod-section--systems" id="systems" aria-labelledby="systems-title">
-    <div class="hao-prod-section__header">
-      <p class="hao-prod-eyebrow">Selected systems</p>
+  <section class="hao-home-section" id="systems" aria-labelledby="systems-title">
+    <div class="hao-home-section-header">
+      <p class="hao-home-eyebrow">Systems</p>
       <h2 id="systems-title">Public surfaces and working tools.</h2>
       <p>A manually ordered view of systems that have moved beyond notes: data products, local-first tools, training apps, and research infrastructure.</p>
     </div>
 
-    <div class="hao-prod-system-stack">
+    <div class="hao-home-system-stack">
       {% for group in site.data.selected_deployments.groups %}
-        <section class="hao-prod-system-group" aria-labelledby="hao-system-group-{{ group.id }}">
-          <div class="hao-prod-system-group__intro">
-            <p class="hao-prod-card-label">{{ group.kicker }}</p>
+        <section class="hao-home-system-group" aria-labelledby="hao-system-group-{{ group.id }}">
+          <div class="hao-home-system-group-intro">
+            <p class="hao-home-card-label">{{ group.kicker }}</p>
             <h3 id="hao-system-group-{{ group.id }}">{{ group.title }}</h3>
             <p>{{ group.summary }}</p>
           </div>
-          <div class="hao-prod-system-grid">
+          <div class="hao-home-system-grid">
             {% for deployment in group.deployments %}
-              <article class="hao-prod-card hao-prod-card--system">
-                <div class="hao-prod-card__topline">
+              <article class="hao-home-card">
+                <div class="hao-home-card-topline">
                   <span>{{ deployment.ref }}</span>
                   <strong>{{ deployment.status }}</strong>
                 </div>
                 <h4>{{ deployment.title }}</h4>
-                <p class="hao-prod-kind">{{ deployment.kind }}</p>
+                <p class="hao-home-kind">{{ deployment.kind }}</p>
                 <p>{{ deployment.summary }}</p>
-                <div class="hao-prod-link-row">
+                <div class="hao-home-links">
                   {% if deployment.href %}
-                    <a class="hao-prod-text-link" href="{{ deployment.href }}" target="_blank" rel="noopener noreferrer">{{ deployment.primary_label | default: "Open" }} →</a>
+                    <a class="hao-home-text-link" href="{{ deployment.href }}" target="_blank" rel="noopener noreferrer">{{ deployment.primary_label | default: "Open" }} →</a>
                   {% endif %}
                   {% if deployment.secondary_href %}
-                    <a class="hao-prod-text-link" href="{{ deployment.secondary_href }}" target="_blank" rel="noopener noreferrer">{{ deployment.secondary_label | default: "Repository" }} →</a>
+                    <a class="hao-home-text-link" href="{{ deployment.secondary_href }}" target="_blank" rel="noopener noreferrer">{{ deployment.secondary_label | default: "Repository" }} →</a>
                   {% endif %}
                 </div>
               </article>
@@ -143,41 +116,41 @@ home_cta: false
       {% endfor %}
     </div>
 
-    <div class="hao-prod-archive-links">
+    <div class="hao-home-archive-links">
       <a href="{{ '/projects/' | relative_url }}">Full project archive</a>
       <a href="{{ '/repositories/' | relative_url }}">Repository archive</a>
     </div>
   </section>
 
-  <section class="hao-prod-section hao-prod-section--knowledge" id="knowledge" aria-labelledby="knowledge-title">
-    <div class="hao-prod-section__header">
-      <p class="hao-prod-eyebrow">Knowledge work</p>
+  <section class="hao-home-section" id="knowledge" aria-labelledby="knowledge-title">
+    <div class="hao-home-section-header">
+      <p class="hao-home-eyebrow">Knowledge</p>
       <h2 id="knowledge-title">Research records and field notes in one workspace.</h2>
       <p>The homepage keeps formal research artifacts and working notes close together, because the same evidence base feeds both.</p>
     </div>
 
-    <div class="hao-prod-knowledge-grid">
-      <div class="hao-prod-knowledge-panel" id="research">
-        <div class="hao-prod-panel-heading">
-          <p class="hao-prod-card-label">Research record</p>
+    <div class="hao-home-knowledge-grid">
+      <div class="hao-home-knowledge-panel" id="research">
+        <div class="hao-home-panel-heading">
+          <p class="hao-home-card-label">Research record</p>
           <h3>Evidence, papers, and technical artifacts.</h3>
         </div>
-        <div class="hao-prod-record-list">
+        <div class="hao-home-record-list">
           {% for record in site.data.research_records.records %}
-            <article class="hao-prod-record">
-              <div class="hao-prod-card__topline">
+            <article class="hao-home-record">
+              <div class="hao-home-card-topline">
                 <span>{{ record.id }}</span>
                 <strong>{{ record.status }}</strong>
               </div>
               <h4>{{ record.title }}</h4>
-              <p class="hao-prod-kind">{{ record.kind }}</p>
+              <p class="hao-home-kind">{{ record.kind }}</p>
               <p>{{ record.summary }}</p>
-              <div class="hao-prod-link-row">
+              <div class="hao-home-links">
                 {% if record.href %}
-                  <a class="hao-prod-text-link" href="{{ record.href }}" target="_blank" rel="noopener noreferrer">{{ record.label | default: "Open" }} →</a>
+                  <a class="hao-home-text-link" href="{{ record.href }}" target="_blank" rel="noopener noreferrer">{{ record.label | default: "Open" }} →</a>
                 {% endif %}
                 {% if record.secondary_href %}
-                  <a class="hao-prod-text-link" href="{{ record.secondary_href }}">{{ record.secondary_label | default: "More" }} →</a>
+                  <a class="hao-home-text-link" href="{{ record.secondary_href }}">{{ record.secondary_label | default: "More" }} →</a>
                 {% endif %}
               </div>
             </article>
@@ -185,42 +158,42 @@ home_cta: false
         </div>
       </div>
 
-      <div class="hao-prod-knowledge-panel" id="notes">
-        <div class="hao-prod-panel-heading">
-          <p class="hao-prod-card-label">Field observations</p>
+      <div class="hao-home-knowledge-panel" id="notes">
+        <div class="hao-home-panel-heading">
+          <p class="hao-home-card-label">Field observations</p>
           <h3>Notes from the edge of the work.</h3>
         </div>
-        <div class="hao-prod-note-list">
+        <div class="hao-home-note-list">
           {% for observation in site.data.field_observations.observations %}
-            <article class="hao-prod-note">
-              <div class="hao-prod-card__topline">
+            <article class="hao-home-note">
+              <div class="hao-home-card-topline">
                 <span>{{ observation.id }}</span>
                 <strong>{{ observation.status }}</strong>
               </div>
               <h4>{{ observation.title }}</h4>
               <p>{{ observation.summary }}</p>
               {% if observation.href %}
-                <a class="hao-prod-text-link" href="{{ observation.href }}">{{ observation.label | default: "Read" }} →</a>
+                <a class="hao-home-text-link" href="{{ observation.href }}">{{ observation.label | default: "Read" }} →</a>
               {% endif %}
             </article>
           {% endfor %}
         </div>
-        <div class="hao-prod-archive-links hao-prod-archive-links--compact">
+        <div class="hao-home-archive-links">
           <a href="{{ '/blog/' | relative_url }}">Full notes archive</a>
         </div>
       </div>
     </div>
   </section>
 
-  <section class="hao-prod-section hao-prod-section--trajectory" id="trajectory" aria-labelledby="trajectory-title">
-    <div class="hao-prod-section__header">
-      <p class="hao-prod-eyebrow">Career trajectory</p>
+  <section class="hao-home-section" id="trajectory" aria-labelledby="trajectory-title">
+    <div class="hao-home-section-header">
+      <p class="hao-home-eyebrow">Trajectory</p>
       <h2 id="trajectory-title">A path from field operations to product systems.</h2>
     </div>
-    <div class="hao-prod-timeline">
+    <div class="hao-home-timeline">
       {% for phase in site.data.career_trajectory.phases %}
-        <article class="hao-prod-timeline-item">
-          <div class="hao-prod-card__topline">
+        <article class="hao-home-timeline-item">
+          <div class="hao-home-card-topline">
             <span>{{ phase.id }}</span>
             <strong>{{ phase.status }}</strong>
           </div>
@@ -229,17 +202,17 @@ home_cta: false
         </article>
       {% endfor %}
     </div>
-    <div class="hao-prod-archive-links">
+    <div class="hao-home-archive-links">
       <a href="{{ '/cv/' | relative_url }}">Full CV archive</a>
     </div>
   </section>
 
-  <section class="hao-prod-contact" id="contact" aria-labelledby="contact-title">
+  <section class="hao-home-contact" id="contact" aria-labelledby="contact-title">
     <div>
-      <p class="hao-prod-eyebrow">Contact</p>
+      <p class="hao-home-eyebrow">Contact</p>
       <h2 id="contact-title">Code, records, notes, and support.</h2>
     </div>
-    <div class="hao-prod-contact__links">
+    <div class="hao-home-contact-links">
       <a href="https://github.com/liuh886" target="_blank" rel="noopener noreferrer">GitHub</a>
       <a href="https://www.linkedin.com/in/liuzhihao" target="_blank" rel="noopener noreferrer">LinkedIn</a>
       <a href="{{ '/cv/' | relative_url }}">CV</a>

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -1,43 +1,17 @@
 # frozen_string_literal: true
 
 module SiteVisualPolish
-  TARGET_PAGES = [
-    "_pages/about.md",
-    "_pages/blog.md",
-    "_pages/portfolio.md",
-    "_pages/projects.md",
-    "_pages/repositories.md",
-    "cv.md"
-  ].freeze
-
-  TARGET_URLS = [
-    "/",
-    "/blog/",
-    "/portfolio/",
-    "/projects/",
-    "/repositories/",
-    "/cv/"
-  ].freeze
-
-  TARGET_URL_PREFIXES = [
-    "/blog/",
-    "/projects/"
-  ].freeze
-
-  # Keep this list intentionally short. Older Mission Log experiment layers are
-  # no longer loaded; the homepage is governed by the safe layer plus the final
-  # al-folio-compatible production homepage layer.
-  STYLESHEETS = [
-    "site-polish.css",
-    "site-upgrade.css",
-    "hao-design.css",
-    "hao-home-safe.css",
+  # Keep the starter close to upstream al-folio by default. Secondary pages such
+  # as Blog, Projects, Repositories, and CV should use the theme's native visual
+  # grammar unless a change is deliberately made in the theme/gem layer.
+  HOMEPAGE_STYLESHEETS = [
     "hao-home-center-fix.css"
   ].freeze
 
-  # Bump this value whenever the final visual layer changes. GitHub Pages and
-  # browsers may otherwise keep serving an older CSS response for the same path.
-  STYLESHEET_VERSION = "20260802-alfolio-wide-home".freeze
+  # Bump this value whenever the homepage enhancement layer changes. GitHub
+  # Pages and browsers may otherwise keep serving an older CSS response for the
+  # same path.
+  STYLESHEET_VERSION = "20260802-alfolio-baseline".freeze
 
   def self.apply_cv_title(page)
     return unless page.relative_path == "cv.md"
@@ -52,38 +26,30 @@ module SiteVisualPolish
     page.relative_path == "_pages/about.md" || page.url.to_s == "/"
   end
 
-  def self.target_page?(page)
-    url = page.url.to_s
-
-    TARGET_PAGES.include?(page.relative_path) ||
-      TARGET_URLS.include?(url) ||
-      TARGET_URL_PREFIXES.any? { |prefix| url.start_with?(prefix) }
-  end
-
   def self.apply_home_navbar_brand(page)
     return unless home_page?(page)
-    return unless page.output.include?("hao-home--production")
+    return unless page.output.include?("hao-home--alfolio")
     return if page.output.include?("hao-home-navbar-brand")
 
     baseurl = page.site.config["baseurl"].to_s.sub(%r{/$}, "")
     home_href = baseurl.empty? ? "/" : "#{baseurl}/"
 
-    # al-folio intentionally omits the navbar brand on the homepage. For this
-    # customized homepage, reinsert the same native brand markup used by the
-    # upstream header on secondary pages instead of fabricating text with CSS.
+    # Upstream al-folio intentionally omits the navbar brand on the homepage,
+    # while secondary pages render it. Reinsert the same semantic brand pattern
+    # on this customized homepage so the site remains visually consistent.
     brand = %(<a class="navbar-brand title font-weight-lighter hao-home-navbar-brand" data-hao-home-brand="true" href="#{home_href}"><span class="font-weight-bold">Zhihao</span> LIU</a>)
 
     navbar_container = %r{(<nav[^>]*class="[^"]*\bnavbar\b[^"]*"[^>]*>\s*<div[^>]*class="[^"]*\bcontainer(?:-fluid)?\b[^"]*"[^>]*>)}m
     page.output = page.output.sub(navbar_container, "\\1\n      #{brand}")
   end
 
-  def self.apply_stylesheet(page)
-    return unless target_page?(page)
+  def self.apply_homepage_stylesheet(page)
+    return unless home_page?(page)
     return unless page.output.include?("</head>")
 
     baseurl = page.site.config["baseurl"].to_s.sub(%r{/$}, "")
 
-    STYLESHEETS.each do |stylesheet|
+    HOMEPAGE_STYLESHEETS.each do |stylesheet|
       next if page.output.include?(stylesheet)
 
       href = "#{baseurl}/assets/css/#{stylesheet}?v=#{STYLESHEET_VERSION}"
@@ -97,6 +63,6 @@ end
   Jekyll::Hooks.register hook_owner, :post_render do |page|
     SiteVisualPolish.apply_cv_title(page)
     SiteVisualPolish.apply_home_navbar_brand(page)
-    SiteVisualPolish.apply_stylesheet(page)
+    SiteVisualPolish.apply_homepage_stylesheet(page)
   end
 end

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -26,7 +26,7 @@ module SiteVisualPolish
 
   # Keep this list intentionally short. Older Mission Log experiment layers are
   # no longer loaded; the homepage is governed by the safe layer plus the final
-  # production homepage layer.
+  # al-folio-compatible production homepage layer.
   STYLESHEETS = [
     "site-polish.css",
     "site-upgrade.css",
@@ -37,9 +37,7 @@ module SiteVisualPolish
 
   # Bump this value whenever the final visual layer changes. GitHub Pages and
   # browsers may otherwise keep serving an older CSS response for the same path.
-  STYLESHEET_VERSION = "20260802-shell-navbar-fix".freeze
-
-  HOMEPAGE_BRAND = "Zhihao LIU".freeze
+  STYLESHEET_VERSION = "20260802-alfolio-wide-home".freeze
 
   def self.apply_cv_title(page)
     return unless page.relative_path == "cv.md"
@@ -69,7 +67,11 @@ module SiteVisualPolish
 
     baseurl = page.site.config["baseurl"].to_s.sub(%r{/$}, "")
     home_href = baseurl.empty? ? "/" : "#{baseurl}/"
-    brand = %(<a class="navbar-brand hao-home-navbar-brand" data-hao-home-brand="true" href="#{home_href}">#{HOMEPAGE_BRAND}</a>)
+
+    # al-folio intentionally omits the navbar brand on the homepage. For this
+    # customized homepage, reinsert the same native brand markup used by the
+    # upstream header on secondary pages instead of fabricating text with CSS.
+    brand = %(<a class="navbar-brand title font-weight-lighter hao-home-navbar-brand" data-hao-home-brand="true" href="#{home_href}"><span class="font-weight-bold">Zhihao</span> LIU</a>)
 
     navbar_container = %r{(<nav[^>]*class="[^"]*\bnavbar\b[^"]*"[^>]*>\s*<div[^>]*class="[^"]*\bcontainer(?:-fluid)?\b[^"]*"[^>]*>)}m
     page.output = page.output.sub(navbar_container, "\\1\n      #{brand}")

--- a/assets/css/hao-home-center-fix.css
+++ b/assets/css/hao-home-center-fix.css
@@ -1,10 +1,10 @@
 /*
- * al-folio-compatible wide homepage layer
+ * al-folio baseline homepage enhancement
  *
- * This layer restores the homepage to the native al-folio about-page grammar:
- * navbar > .container, main > .container, .post, .post-header, article, and
- * clearfix. It only widens the native shell and adds compatible content modules
- * for the homepage records. It is not a standalone landing-page shell.
+ * The whole site should look like upstream al-folio by default. This single
+ * homepage-only layer widens the native about-page shell and adds lightweight
+ * content modules inside the original .post / article / clearfix flow. It does
+ * not restyle Blog, Projects, Repositories, CV, or secondary pages.
  */
 
 :root {
@@ -13,7 +13,7 @@
   --hao-alfolio-shell: min(calc(100% - var(--hao-alfolio-gutter) - var(--hao-alfolio-gutter)), var(--hao-alfolio-shell-max));
   --hao-home-ink: var(--global-text-color, #111827);
   --hao-home-muted: var(--global-text-color-light, #6b7280);
-  --hao-home-accent: var(--hao-mission-accent, #b80fb8);
+  --hao-home-accent: var(--global-theme-color, #b80fb8);
   --hao-home-line: var(--global-divider-color, #e5e7eb);
   --hao-home-card-bg: var(--global-bg-color, #ffffff);
   --hao-home-soft: color-mix(in srgb, var(--hao-home-accent) 5%, var(--global-bg-color, #ffffff));
@@ -38,7 +38,7 @@ body:has(.hao-home--alfolio) .post {
   max-width: none;
 }
 
-/* Undo the old rescue layer so the native about layout is visible again. */
+/* Keep the native al-folio about-page surface visible. */
 body:has(.hao-home--alfolio) .post > header,
 body:has(.hao-home--alfolio) .post-header,
 body:has(.hao-home--alfolio) .post-title,
@@ -53,19 +53,13 @@ body:has(.hao-home--alfolio) .post-header {
   margin-bottom: 1.75rem;
 }
 
-body:has(.hao-home--alfolio) .post-title {
-  color: var(--hao-home-ink);
-}
-
 body:has(.hao-home--alfolio) .desc {
   max-width: 42rem;
-  color: var(--hao-home-muted);
 }
 
 /* Homepage brand: same semantic class stack as the upstream al-folio header. */
 body:has(.hao-home--alfolio) .hao-home-navbar-brand {
   display: inline-block !important;
-  color: var(--hao-home-ink) !important;
   text-decoration: none !important;
   visibility: visible !important;
   opacity: 1 !important;
@@ -79,7 +73,6 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 .hao-home--alfolio {
   clear: both;
   margin-top: 1.25rem;
-  color: var(--hao-home-ink);
 }
 
 .hao-home--alfolio *,

--- a/assets/css/hao-home-center-fix.css
+++ b/assets/css/hao-home-center-fix.css
@@ -1,758 +1,402 @@
 /*
- * Production homepage shell and navbar hardening layer
+ * al-folio-compatible wide homepage layer
  *
- * This is the only final homepage layer. It fixes the two production issues that
- * kept recurring: inconsistent page widths and a missing homepage navbar brand.
- * The homepage, navbar, hero, sections, and cards now all use the same shell.
+ * This layer restores the homepage to the native al-folio about-page grammar:
+ * navbar > .container, main > .container, .post, .post-header, article, and
+ * clearfix. It only widens the native shell and adds compatible content modules
+ * for the homepage records. It is not a standalone landing-page shell.
  */
 
 :root {
-  --hao-page-shell-max: 76rem;
-  --hao-page-gutter: clamp(1rem, 4vw, 2.75rem);
-  --hao-page-shell: min(calc(100vw - (2 * var(--hao-page-gutter))), var(--hao-page-shell-max));
-  --hao-prod-ink: var(--global-text-color, #111827);
-  --hao-prod-muted: color-mix(in srgb, var(--hao-prod-ink) 58%, white);
-  --hao-prod-accent: var(--hao-mission-accent, #b80fb8);
-  --hao-prod-accent-2: #6d5dfc;
-  --hao-prod-accent-3: #22c1c3;
-  --hao-prod-line: color-mix(in srgb, var(--hao-prod-accent) 14%, #e5e7eb);
-  --hao-prod-line-strong: color-mix(in srgb, var(--hao-prod-accent) 27%, #d1d5db);
-  --hao-prod-surface: color-mix(in srgb, #ffffff 92%, color-mix(in srgb, var(--hao-prod-accent) 7%, white));
-  --hao-prod-surface-strong: #ffffff;
-  --hao-prod-shadow: 0 24px 70px rgba(17, 24, 39, 0.075);
-  --hao-prod-shadow-soft: 0 16px 42px rgba(17, 24, 39, 0.055);
-  --hao-prod-radius-xl: 2rem;
-  --hao-prod-radius-lg: 1.35rem;
-  --hao-prod-radius-md: 1rem;
+  --hao-alfolio-shell-max: 72rem;
+  --hao-alfolio-gutter: clamp(1rem, 4vw, 2rem);
+  --hao-alfolio-shell: min(calc(100% - var(--hao-alfolio-gutter) - var(--hao-alfolio-gutter)), var(--hao-alfolio-shell-max));
+  --hao-home-ink: var(--global-text-color, #111827);
+  --hao-home-muted: var(--global-text-color-light, #6b7280);
+  --hao-home-accent: var(--hao-mission-accent, #b80fb8);
+  --hao-home-line: var(--global-divider-color, #e5e7eb);
+  --hao-home-card-bg: var(--global-bg-color, #ffffff);
+  --hao-home-soft: color-mix(in srgb, var(--hao-home-accent) 5%, var(--global-bg-color, #ffffff));
 }
 
-html:has(.hao-home--production),
-body:has(.hao-home--production) {
+html:has(.hao-home--alfolio),
+body:has(.hao-home--alfolio) {
   overflow-x: clip;
 }
 
-body:has(.hao-home--production) {
-  background:
-    radial-gradient(circle at 8% 6%, color-mix(in srgb, var(--hao-prod-accent) 11%, transparent) 0, transparent 28rem),
-    radial-gradient(circle at 88% 10%, color-mix(in srgb, var(--hao-prod-accent-2) 10%, transparent) 0, transparent 30rem),
-    linear-gradient(180deg, #ffffff 0%, color-mix(in srgb, var(--hao-prod-accent) 3%, #ffffff) 48%, #ffffff 100%);
-}
-
-body:has(.hao-home--production) main,
-body:has(.hao-home--production) main > .container,
-body:has(.hao-home--production) .container:has(.hao-home--production),
-body:has(.hao-home--production) .post,
-body:has(.hao-home--production) article.post {
-  width: 100% !important;
-  max-width: none !important;
-  margin-right: 0 !important;
-  margin-left: 0 !important;
-  padding-right: 0 !important;
-  padding-left: 0 !important;
-}
-
-body:has(.hao-home--production) header,
-body:has(.hao-home--production) .navbar {
-  background: color-mix(in srgb, #ffffff 88%, transparent) !important;
-  border-bottom: 1px solid color-mix(in srgb, var(--hao-prod-line) 72%, transparent) !important;
-  backdrop-filter: blur(18px);
-}
-
-body:has(.hao-home--production) .navbar .container,
-body:has(.hao-home--production) .navbar .container-fluid,
-.hao-home--production {
-  box-sizing: border-box !important;
-  width: var(--hao-page-shell) !important;
-  max-width: var(--hao-page-shell-max) !important;
+body:has(.hao-home--alfolio) main > .container,
+body:has(.hao-home--alfolio) .navbar > .container,
+body:has(.hao-home--alfolio) .navbar > .container-fluid {
+  width: var(--hao-alfolio-shell) !important;
+  max-width: var(--hao-alfolio-shell-max) !important;
   margin-right: auto !important;
   margin-left: auto !important;
 }
 
-body:has(.hao-home--production) .navbar .container,
-body:has(.hao-home--production) .navbar .container-fluid {
-  display: flex !important;
-  align-items: center !important;
-  justify-content: space-between !important;
-  padding-right: 0 !important;
-  padding-left: 0 !important;
+body:has(.hao-home--alfolio) .post {
+  width: 100%;
+  max-width: none;
 }
 
-/* The homepage brand is a real injected anchor, not pseudo-element text. */
-body:has(.hao-home--production) .navbar .navbar-brand:not(.hao-home-navbar-brand) {
-  display: none !important;
-}
-
-body:has(.hao-home--production) .hao-home-navbar-brand {
-  display: inline-flex !important;
-  flex: 0 0 auto !important;
-  align-items: center !important;
-  min-width: max-content !important;
-  margin-right: clamp(1.25rem, 3vw, 2.5rem) !important;
-  padding: 0 !important;
-  color: var(--hao-prod-ink) !important;
-  font-size: clamp(1.22rem, 1.75vw, 1.7rem) !important;
-  font-weight: 430 !important;
-  letter-spacing: -0.04em !important;
-  line-height: 1 !important;
-  text-decoration: none !important;
-  text-transform: none !important;
-  opacity: 1 !important;
+/* Undo the old rescue layer so the native about layout is visible again. */
+body:has(.hao-home--alfolio) .post > header,
+body:has(.hao-home--alfolio) .post-header,
+body:has(.hao-home--alfolio) .post-title,
+body:has(.hao-home--alfolio) .post-description,
+body:has(.hao-home--alfolio) .profile {
+  display: revert !important;
   visibility: visible !important;
+  opacity: 1 !important;
 }
 
-body:has(.hao-home--production) .hao-home-navbar-brand::before,
-body:has(.hao-home--production) .hao-home-navbar-brand::after {
+body:has(.hao-home--alfolio) .post-header {
+  margin-bottom: 1.75rem;
+}
+
+body:has(.hao-home--alfolio) .post-title {
+  color: var(--hao-home-ink);
+}
+
+body:has(.hao-home--alfolio) .desc {
+  max-width: 42rem;
+  color: var(--hao-home-muted);
+}
+
+/* Homepage brand: same semantic class stack as the upstream al-folio header. */
+body:has(.hao-home--alfolio) .hao-home-navbar-brand {
+  display: inline-block !important;
+  color: var(--hao-home-ink) !important;
+  text-decoration: none !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}
+
+body:has(.hao-home--alfolio) .hao-home-navbar-brand::before,
+body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
   content: none !important;
 }
 
-body:has(.hao-home--production) .navbar-collapse {
-  flex: 1 1 auto !important;
-  justify-content: flex-end !important;
+.hao-home--alfolio {
+  clear: both;
+  margin-top: 1.25rem;
+  color: var(--hao-home-ink);
 }
 
-body:has(.hao-home--production) .navbar-nav {
-  display: flex !important;
-  align-items: center !important;
-  justify-content: flex-end !important;
-  width: auto !important;
-  margin-left: auto !important;
-  gap: clamp(0.2rem, 0.7vw, 0.55rem);
-}
-
-body:has(.hao-home--production) .navbar-nav .nav-link {
-  border-radius: 999px;
-  padding: 0.45rem 0.7rem !important;
-  color: color-mix(in srgb, var(--hao-prod-ink) 70%, transparent) !important;
-  font-size: clamp(0.9rem, 1.02vw, 1rem) !important;
-  font-weight: 520 !important;
-  letter-spacing: -0.02em !important;
-  text-transform: none !important;
-}
-
-body:has(.hao-home--production) .navbar-nav .nav-link:hover,
-body:has(.hao-home--production) .navbar-nav .nav-link:focus-visible,
-body:has(.hao-home--production) .navbar-nav .active > .nav-link,
-body:has(.hao-home--production) .navbar-nav .nav-link.active {
-  background: color-mix(in srgb, var(--hao-prod-accent) 7%, transparent);
-  color: var(--hao-prod-accent) !important;
-}
-
-.hao-home--production {
-  position: relative;
-  padding: clamp(2.6rem, 5.5vw, 5.2rem) 0 clamp(4rem, 8vw, 7rem) !important;
-  color: var(--hao-prod-ink);
-}
-
-.hao-home--production *,
-.hao-home--production *::before,
-.hao-home--production *::after {
+.hao-home--alfolio *,
+.hao-home--alfolio *::before,
+.hao-home--alfolio *::after {
   box-sizing: border-box;
 }
 
-.hao-home--production a {
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 0.22em;
+.hao-home-intro {
+  max-width: 43rem;
+  margin: 0 0 2.25rem;
 }
 
-.hao-prod-hero,
-.hao-prod-section,
-.hao-prod-contact {
-  width: 100%;
-}
-
-.hao-prod-hero {
-  position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 1.06fr) minmax(18rem, 0.6fr);
-  gap: clamp(2rem, 6vw, 5.25rem);
-  align-items: center;
-  padding: clamp(2.4rem, 5vw, 4.8rem);
-  overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--hao-prod-accent) 15%, #e5e7eb);
-  border-radius: clamp(1.5rem, 3vw, var(--hao-prod-radius-xl));
-  background:
-    radial-gradient(circle at 8% 16%, color-mix(in srgb, var(--hao-prod-accent) 16%, transparent) 0, transparent 18rem),
-    radial-gradient(circle at 76% 18%, color-mix(in srgb, var(--hao-prod-accent-2) 12%, transparent) 0, transparent 20rem),
-    linear-gradient(135deg, color-mix(in srgb, #ffffff 92%, var(--hao-prod-accent)) 0%, #ffffff 46%, color-mix(in srgb, #ffffff 86%, var(--hao-prod-accent-3)) 100%);
-  box-shadow: var(--hao-prod-shadow);
-}
-
-.hao-prod-hero::before {
-  position: absolute;
-  inset: 1px;
-  z-index: 0;
-  pointer-events: none;
-  content: "";
-  border-radius: inherit;
-  background:
-    linear-gradient(90deg, rgba(255,255,255,0.34) 1px, transparent 1px),
-    linear-gradient(180deg, rgba(255,255,255,0.38) 1px, transparent 1px);
-  background-size: 3.6rem 3.6rem;
-  mask-image: linear-gradient(135deg, black, transparent 78%);
-  opacity: 0.44;
-}
-
-.hao-prod-hero::after {
-  position: absolute;
-  right: -7rem;
-  bottom: -8rem;
-  width: 24rem;
-  height: 24rem;
-  pointer-events: none;
-  content: "";
-  border-radius: 50%;
-  background: radial-gradient(circle, color-mix(in srgb, var(--hao-prod-accent) 18%, transparent), transparent 68%);
-  filter: blur(4px);
-}
-
-.hao-prod-hero__content,
-.hao-prod-profile {
-  position: relative;
-  z-index: 1;
-}
-
-.hao-prod-hero__content {
-  max-width: 47rem;
-}
-
-.hao-prod-eyebrow,
-.hao-prod-card-label {
-  margin: 0;
-  color: var(--hao-prod-accent);
+.hao-home-eyebrow,
+.hao-home-card-label {
+  margin: 0 0 0.45rem;
+  color: var(--hao-home-accent);
   font-size: 0.72rem;
-  font-weight: 760;
-  letter-spacing: 0.16em;
+  font-weight: 700;
+  letter-spacing: 0.12em;
   line-height: 1.35;
   text-transform: uppercase;
 }
 
-.hao-prod-hero h1 {
-  max-width: 12ch;
-  margin: 0.85rem 0 0;
-  color: var(--hao-prod-ink);
-  font-size: clamp(3.05rem, 6.2vw, 5.7rem);
-  font-weight: 690;
-  letter-spacing: -0.074em;
-  line-height: 0.94;
-  text-wrap: balance;
-}
-
-.hao-prod-lede {
-  max-width: 44rem;
-  margin: clamp(1.2rem, 2.4vw, 1.7rem) 0 0;
-  color: color-mix(in srgb, var(--hao-prod-ink) 72%, white);
-  font-size: clamp(1.04rem, 1.35vw, 1.24rem);
-  line-height: 1.66;
-}
-
-.hao-prod-actions,
-.hao-prod-archive-links,
-.hao-prod-link-row,
-.hao-prod-contact__links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.72rem;
-}
-
-.hao-prod-actions {
-  margin-top: clamp(1.35rem, 3vw, 2rem);
-}
-
-.hao-prod-button,
-.hao-prod-archive-links a,
-.hao-prod-contact__links a {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.7rem;
-  border: 1px solid var(--hao-prod-line);
-  border-radius: 999px;
-  padding: 0.72rem 1.05rem;
-  background: color-mix(in srgb, #ffffff 88%, transparent);
-  color: var(--hao-prod-ink) !important;
-  font-size: 0.88rem;
-  font-weight: 680;
-  line-height: 1;
-  text-decoration: none !important;
-  box-shadow: 0 6px 20px rgba(17, 24, 39, 0.035);
-  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
-}
-
-.hao-prod-button:hover,
-.hao-prod-button:focus-visible,
-.hao-prod-archive-links a:hover,
-.hao-prod-archive-links a:focus-visible,
-.hao-prod-contact__links a:hover,
-.hao-prod-contact__links a:focus-visible {
-  transform: translateY(-1px);
-  border-color: var(--hao-prod-line-strong);
-  background: #ffffff;
-  box-shadow: var(--hao-prod-shadow-soft);
-}
-
-.hao-prod-button--primary {
-  border-color: color-mix(in srgb, var(--hao-prod-accent) 78%, #ffffff);
-  background: linear-gradient(135deg, var(--hao-prod-accent), var(--hao-prod-accent-2));
-  color: #ffffff !important;
-  box-shadow: 0 14px 34px color-mix(in srgb, var(--hao-prod-accent) 21%, transparent);
-}
-
-.hao-prod-profile {
-  justify-self: end;
-  width: 100%;
-  max-width: 24rem;
-  overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--hao-prod-accent) 18%, #e5e7eb);
-  border-radius: 1.7rem;
-  padding: 1rem;
-  background:
-    linear-gradient(160deg, color-mix(in srgb, #ffffff 90%, var(--hao-prod-accent)), #ffffff 58%, color-mix(in srgb, #ffffff 86%, var(--hao-prod-accent-2)));
-  box-shadow: var(--hao-prod-shadow-soft);
-}
-
-.hao-prod-profile__glow {
-  position: absolute;
-  right: -4.5rem;
-  top: -4rem;
-  width: 13rem;
-  height: 13rem;
-  border-radius: 50%;
-  background: radial-gradient(circle, color-mix(in srgb, var(--hao-prod-accent) 24%, transparent), transparent 68%);
-}
-
-.hao-prod-profile__portrait {
-  position: relative;
-  z-index: 1;
+.hao-home-intro h2 {
+  max-width: 13em;
   margin: 0;
-  overflow: hidden;
-  border: 1px solid var(--hao-prod-line);
-  border-radius: 1.25rem;
-  background: #ffffff;
-}
-
-.hao-prod-profile__portrait img {
-  display: block;
-  width: 100%;
-  aspect-ratio: 4 / 4.4;
-  object-fit: cover;
-}
-
-.hao-prod-profile__body {
-  position: relative;
-  z-index: 1;
-  padding: 1rem 0.25rem 0.2rem;
-}
-
-.hao-prod-profile h2 {
-  margin: 0.45rem 0 0;
-  color: var(--hao-prod-ink);
-  font-size: clamp(1.32rem, 1.8vw, 1.62rem);
+  color: var(--hao-home-ink);
+  font-size: clamp(1.85rem, 3.6vw, 3rem);
+  font-weight: 500;
   letter-spacing: -0.045em;
-  line-height: 1.02;
+  line-height: 1.05;
 }
 
-.hao-prod-profile p:not(.hao-prod-card-label) {
-  margin: 0.55rem 0 0;
-  color: var(--hao-prod-muted);
-  font-size: 0.94rem;
-  line-height: 1.58;
+.hao-home-intro p:not(.hao-home-eyebrow) {
+  max-width: 40rem;
+  margin: 0.9rem 0 0;
+  color: var(--hao-home-muted);
+  font-size: 1.02rem;
+  line-height: 1.7;
 }
 
-.hao-prod-profile__facts {
-  display: grid;
-  gap: 0.5rem;
-  margin: 1rem 0 0;
-}
-
-.hao-prod-profile__facts div {
-  display: grid;
-  grid-template-columns: 4.2rem minmax(0, 1fr);
-  gap: 0.75rem;
-  align-items: baseline;
-}
-
-.hao-prod-profile__facts dt,
-.hao-prod-profile__facts dd {
-  margin: 0;
-  font-size: 0.76rem;
-  line-height: 1.35;
-}
-
-.hao-prod-profile__facts dt {
-  color: var(--hao-prod-muted);
-  font-weight: 740;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.hao-prod-profile__facts dd {
-  color: var(--hao-prod-ink);
-  font-weight: 680;
-}
-
-.hao-prod-index {
-  position: sticky;
-  top: 0.2rem;
-  z-index: 5;
+.hao-home-actions,
+.hao-home-links,
+.hao-home-contact-links,
+.hao-home-archive-links {
   display: flex;
   flex-wrap: wrap;
   gap: 0.55rem;
-  align-items: center;
-  margin: clamp(1rem, 2.3vw, 1.6rem) 0 0;
-  padding: 0.72rem 0;
-  border-bottom: 1px solid color-mix(in srgb, var(--hao-prod-line) 68%, transparent);
-  background: color-mix(in srgb, #ffffff 72%, transparent);
-  backdrop-filter: blur(16px);
 }
 
-.hao-prod-index a {
-  border: 1px solid transparent;
+.hao-home-actions {
+  margin-top: 1.15rem;
+}
+
+.hao-home-button,
+.hao-home-contact-links a,
+.hao-home-archive-links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.35rem;
+  border: 1px solid var(--hao-home-line);
   border-radius: 999px;
-  padding: 0.38rem 0.62rem;
-  color: color-mix(in srgb, var(--hao-prod-ink) 58%, white);
-  font-size: 0.76rem;
-  font-weight: 720;
+  padding: 0.58rem 0.82rem;
+  background: var(--hao-home-card-bg);
+  color: var(--hao-home-ink) !important;
+  font-size: 0.86rem;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none !important;
+  transition: border-color 160ms ease, color 160ms ease, background 160ms ease;
+}
+
+.hao-home-button:hover,
+.hao-home-button:focus-visible,
+.hao-home-contact-links a:hover,
+.hao-home-contact-links a:focus-visible,
+.hao-home-archive-links a:hover,
+.hao-home-archive-links a:focus-visible {
+  border-color: color-mix(in srgb, var(--hao-home-accent) 45%, var(--hao-home-line));
+  background: var(--hao-home-soft);
+  color: var(--hao-home-accent) !important;
+}
+
+.hao-home-button--primary {
+  border-color: color-mix(in srgb, var(--hao-home-accent) 55%, var(--hao-home-line));
+  background: var(--hao-home-soft);
+  color: var(--hao-home-accent) !important;
+}
+
+.hao-home-index {
+  clear: both;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.7rem;
+  align-items: center;
+  margin: 2rem 0 0;
+  padding: 0.85rem 0;
+  border-top: 1px solid var(--hao-home-line);
+  border-bottom: 1px solid var(--hao-home-line);
+}
+
+.hao-home-index a {
+  color: var(--hao-home-muted);
+  font-size: 0.78rem;
+  font-weight: 650;
   letter-spacing: 0.04em;
   text-decoration: none;
   text-transform: uppercase;
 }
 
-.hao-prod-index a:hover,
-.hao-prod-index a:focus-visible {
-  border-color: var(--hao-prod-line);
-  color: var(--hao-prod-accent);
+.hao-home-index a:hover,
+.hao-home-index a:focus-visible {
+  color: var(--hao-home-accent);
+  text-decoration: none;
 }
 
-.hao-prod-section {
+.hao-home-section,
+.hao-home-contact {
+  clear: both;
   display: grid;
-  grid-template-columns: minmax(13rem, 0.33fr) minmax(0, 1fr);
-  gap: clamp(1.7rem, 4.5vw, 4rem);
-  padding: clamp(3.2rem, 6vw, 5rem) 0;
-  border-bottom: 1px solid color-mix(in srgb, var(--hao-prod-line) 66%, transparent);
-  scroll-margin-top: 5.5rem;
+  grid-template-columns: minmax(11rem, 0.28fr) minmax(0, 1fr);
+  gap: clamp(1.2rem, 3.4vw, 2.6rem);
+  padding: clamp(2rem, 4.5vw, 3.4rem) 0;
+  border-bottom: 1px solid var(--hao-home-line);
+  scroll-margin-top: 5rem;
 }
 
-.hao-prod-section__header {
-  max-width: 21rem;
-}
-
-.hao-prod-section__header h2,
-.hao-prod-contact h2 {
-  margin: 0.65rem 0 0;
-  color: var(--hao-prod-ink);
-  font-size: clamp(1.85rem, 3.2vw, 2.85rem);
-  font-weight: 670;
-  letter-spacing: -0.058em;
-  line-height: 1.03;
-  text-wrap: balance;
-}
-
-.hao-prod-section__header p:not(.hao-prod-eyebrow) {
-  margin: 1rem 0 0;
-  color: var(--hao-prod-muted);
-  font-size: 0.97rem;
-  line-height: 1.66;
-}
-
-.hao-prod-work-grid,
-.hao-prod-system-grid,
-.hao-prod-knowledge-grid,
-.hao-prod-timeline {
-  display: grid;
-  gap: clamp(0.9rem, 1.8vw, 1.25rem);
-  min-width: 0;
-}
-
-.hao-prod-work-grid,
-.hao-prod-system-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.hao-prod-knowledge-grid {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 0.82fr);
-}
-
-.hao-prod-card,
-.hao-prod-record,
-.hao-prod-note,
-.hao-prod-timeline-item,
-.hao-prod-knowledge-panel,
-.hao-prod-system-group {
-  border: 1px solid color-mix(in srgb, var(--hao-prod-line) 86%, transparent);
-  border-radius: var(--hao-prod-radius-lg);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, #ffffff 96%, var(--hao-prod-accent)), #ffffff 88%),
-    #ffffff;
-  box-shadow: 0 10px 30px rgba(17, 24, 39, 0.035);
-}
-
-.hao-prod-card,
-.hao-prod-record,
-.hao-prod-note,
-.hao-prod-timeline-item {
-  padding: clamp(1rem, 1.8vw, 1.25rem);
-  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
-}
-
-.hao-prod-card:hover,
-.hao-prod-card:focus-within,
-.hao-prod-record:hover,
-.hao-prod-record:focus-within,
-.hao-prod-note:hover,
-.hao-prod-note:focus-within,
-.hao-prod-timeline-item:hover,
-.hao-prod-timeline-item:focus-within {
-  transform: translateY(-2px);
-  border-color: var(--hao-prod-line-strong);
-  box-shadow: var(--hao-prod-shadow-soft);
-}
-
-.hao-prod-card__topline {
-  display: flex;
-  gap: 0.7rem;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.85rem;
-  color: var(--hao-prod-muted);
-  font-size: 0.72rem;
-  font-weight: 740;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.hao-prod-card__topline strong {
-  color: var(--hao-prod-accent);
-  font-weight: 760;
-}
-
-.hao-prod-card h3,
-.hao-prod-card h4,
-.hao-prod-record h4,
-.hao-prod-note h4,
-.hao-prod-timeline-item h3,
-.hao-prod-panel-heading h3,
-.hao-prod-system-group__intro h3 {
+.hao-home-section-header h2,
+.hao-home-contact h2 {
   margin: 0;
-  color: var(--hao-prod-ink);
-  font-weight: 660;
+  color: var(--hao-home-ink);
+  font-size: clamp(1.35rem, 2.2vw, 2rem);
+  font-weight: 500;
   letter-spacing: -0.035em;
-  line-height: 1.15;
+  line-height: 1.12;
 }
 
-.hao-prod-card h3,
-.hao-prod-card h4,
-.hao-prod-record h4,
-.hao-prod-note h4,
-.hao-prod-timeline-item h3 {
-  font-size: clamp(1.02rem, 1.25vw, 1.15rem);
-}
-
-.hao-prod-card p,
-.hao-prod-record p,
-.hao-prod-note p,
-.hao-prod-timeline-item p,
-.hao-prod-system-group__intro p:not(.hao-prod-card-label),
-.hao-prod-panel-heading p:not(.hao-prod-card-label) {
+.hao-home-section-header p:not(.hao-home-eyebrow) {
   margin: 0.72rem 0 0;
-  color: var(--hao-prod-muted);
-  font-size: 0.92rem;
+  color: var(--hao-home-muted);
+  font-size: 0.94rem;
   line-height: 1.62;
 }
 
-.hao-prod-kind {
-  margin-top: 0.45rem !important;
-  color: color-mix(in srgb, var(--hao-prod-accent) 70%, var(--hao-prod-muted)) !important;
-  font-size: 0.78rem !important;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.hao-prod-text-link {
-  display: inline-flex;
-  margin-top: 0.9rem;
-  color: var(--hao-prod-accent) !important;
-  font-size: 0.88rem;
-  font-weight: 720;
-  text-decoration: none !important;
-}
-
-.hao-prod-text-link:hover,
-.hao-prod-text-link:focus-visible {
-  text-decoration: underline !important;
-}
-
-.hao-prod-system-stack {
+.hao-home-card-grid,
+.hao-home-system-grid,
+.hao-home-knowledge-grid,
+.hao-home-timeline {
   display: grid;
-  gap: clamp(1rem, 2vw, 1.35rem);
+  gap: 0.9rem;
 }
 
-.hao-prod-system-group,
-.hao-prod-knowledge-panel {
-  padding: clamp(1rem, 2vw, 1.35rem);
-}
-
-.hao-prod-system-group__intro,
-.hao-prod-panel-heading {
-  max-width: 42rem;
-  margin-bottom: 1rem;
-}
-
-.hao-prod-system-group__intro h3,
-.hao-prod-panel-heading h3 {
-  margin-top: 0.45rem;
-  font-size: clamp(1.25rem, 2vw, 1.7rem);
-}
-
-.hao-prod-record-list,
-.hao-prod-note-list {
-  display: grid;
-  gap: 0.85rem;
-}
-
-.hao-prod-archive-links {
-  grid-column: 2;
-  margin-top: 1.1rem;
-}
-
-.hao-prod-archive-links--compact {
-  margin-top: 1rem;
-}
-
-.hao-prod-timeline {
+.hao-home-card-grid,
+.hao-home-system-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.hao-prod-contact {
-  display: grid;
-  grid-template-columns: minmax(13rem, 0.33fr) minmax(0, 1fr);
-  gap: clamp(1.7rem, 4.5vw, 4rem);
-  padding: clamp(3.2rem, 6vw, 5rem) 0 0;
+.hao-home-card,
+.hao-home-record,
+.hao-home-note,
+.hao-home-timeline-item,
+.hao-home-knowledge-panel {
+  border: 1px solid var(--hao-home-line);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: var(--hao-home-card-bg);
 }
 
-.hao-prod-contact__links {
+.hao-home-card:hover,
+.hao-home-record:hover,
+.hao-home-note:hover,
+.hao-home-timeline-item:hover,
+.hao-home-knowledge-panel:hover {
+  border-color: color-mix(in srgb, var(--hao-home-accent) 35%, var(--hao-home-line));
+}
+
+.hao-home-card-topline {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.65rem;
+  color: var(--hao-home-muted);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.hao-home-card-topline span,
+.hao-home-card-topline strong {
+  font-weight: 650;
+}
+
+.hao-home-card h3,
+.hao-home-card h4,
+.hao-home-record h4,
+.hao-home-note h4,
+.hao-home-timeline-item h3,
+.hao-home-knowledge-panel h3 {
+  margin: 0;
+  color: var(--hao-home-ink);
+  font-size: 1.03rem;
+  font-weight: 550;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+
+.hao-home-card p,
+.hao-home-record p,
+.hao-home-note p,
+.hao-home-timeline-item p,
+.hao-home-knowledge-panel > p {
+  margin: 0.55rem 0 0;
+  color: var(--hao-home-muted);
+  font-size: 0.92rem;
+  line-height: 1.58;
+}
+
+.hao-home-kind {
+  color: var(--hao-home-accent) !important;
+  font-size: 0.78rem !important;
+  font-weight: 650;
+}
+
+.hao-home-text-link {
+  display: inline-flex;
+  margin-top: 0.75rem;
+  color: var(--hao-home-accent) !important;
+  font-size: 0.88rem;
+  font-weight: 650;
+  text-decoration: none !important;
+}
+
+.hao-home-text-link:hover,
+.hao-home-text-link:focus-visible {
+  text-decoration: underline !important;
+}
+
+.hao-home-system-group + .hao-home-system-group,
+.hao-home-record + .hao-home-record,
+.hao-home-note + .hao-home-note {
+  margin-top: 0.9rem;
+}
+
+.hao-home-system-group-intro {
+  margin-bottom: 0.8rem;
+}
+
+.hao-home-system-group-intro h3 {
+  margin: 0;
+  color: var(--hao-home-ink);
+  font-size: 1.15rem;
+  font-weight: 540;
+  letter-spacing: -0.025em;
+}
+
+.hao-home-system-group-intro p:not(.hao-home-card-label) {
+  margin: 0.45rem 0 0;
+  color: var(--hao-home-muted);
+  font-size: 0.92rem;
+  line-height: 1.58;
+}
+
+.hao-home-knowledge-grid {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.hao-home-panel-heading {
+  margin-bottom: 0.85rem;
+}
+
+.hao-home-contact {
+  border-bottom: 0;
+}
+
+.hao-home-contact-links {
   align-content: start;
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 992px) {
   :root {
-    --hao-page-gutter: clamp(1rem, 3.5vw, 2rem);
+    --hao-alfolio-shell-max: 64rem;
+    --hao-alfolio-gutter: clamp(0.9rem, 3.5vw, 1.5rem);
   }
 
-  .hao-prod-hero {
-    gap: clamp(1.7rem, 4.5vw, 3.5rem);
-    padding: clamp(2rem, 4.5vw, 3.5rem);
-  }
-
-  .hao-prod-hero h1 {
-    font-size: clamp(2.85rem, 6.4vw, 4.8rem);
+  .hao-home-section,
+  .hao-home-contact {
+    grid-template-columns: 1fr;
   }
 }
 
-@media (max-width: 900px) {
-  :root {
-    --hao-page-gutter: 1rem;
+@media (max-width: 760px) {
+  body:has(.hao-home--alfolio) main > .container,
+  body:has(.hao-home--alfolio) .navbar > .container,
+  body:has(.hao-home--alfolio) .navbar > .container-fluid {
+    width: min(calc(100% - 1.25rem), 64rem) !important;
   }
 
-  body:has(.hao-home--production) .navbar .container,
-  body:has(.hao-home--production) .navbar .container-fluid,
-  .hao-home--production {
-    width: var(--hao-page-shell) !important;
-    max-width: var(--hao-page-shell-max) !important;
-  }
-
-  body:has(.hao-home--production) .hao-home-navbar-brand {
-    font-size: 1.28rem !important;
-  }
-
-  .hao-home--production {
-    padding-top: 2.4rem !important;
-  }
-
-  .hao-prod-hero,
-  .hao-prod-section,
-  .hao-prod-contact,
-  .hao-prod-knowledge-grid {
+  .hao-home-card-grid,
+  .hao-home-system-grid,
+  .hao-home-knowledge-grid,
+  .hao-home-timeline {
     grid-template-columns: 1fr;
   }
 
-  .hao-prod-profile {
-    justify-self: start;
-    max-width: 29rem;
-  }
-
-  .hao-prod-section__header {
-    max-width: 40rem;
-  }
-
-  .hao-prod-archive-links {
-    grid-column: 1;
-  }
-}
-
-@media (max-width: 680px) {
-  :root {
-    --hao-page-gutter: 0.75rem;
-  }
-
-  body:has(.hao-home--production) .hao-home-navbar-brand {
-    font-size: 1.02rem !important;
-    letter-spacing: -0.025em !important;
-  }
-
-  body:has(.hao-home--production) .navbar-nav .nav-link {
-    font-size: 0.9rem !important;
-  }
-
-  .hao-home--production {
-    padding-top: 2rem !important;
-  }
-
-  .hao-prod-hero {
-    padding: clamp(1.35rem, 6vw, 2rem);
-    border-radius: 1.35rem;
-  }
-
-  .hao-prod-hero h1 {
-    max-width: 13ch;
-    font-size: clamp(2.25rem, 11vw, 3.35rem);
-    letter-spacing: -0.058em;
-  }
-
-  .hao-prod-work-grid,
-  .hao-prod-system-grid,
-  .hao-prod-timeline {
-    grid-template-columns: 1fr;
-  }
-
-  .hao-prod-profile__facts div {
-    grid-template-columns: 1fr;
-    gap: 0.15rem;
-  }
-
-  .hao-prod-index {
-    position: static;
+  .hao-home-intro h2 {
+    font-size: clamp(1.7rem, 8vw, 2.45rem);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hao-prod-button,
-  .hao-prod-card,
-  .hao-prod-record,
-  .hao-prod-note,
-  .hao-prod-timeline-item,
-  .hao-prod-archive-links a,
-  .hao-prod-contact__links a {
-    transition: none !important;
-  }
-
-  .hao-prod-button:hover,
-  .hao-prod-card:hover,
-  .hao-prod-record:hover,
-  .hao-prod-note:hover,
-  .hao-prod-timeline-item:hover,
-  .hao-prod-archive-links a:hover,
-  .hao-prod-contact__links a:hover {
-    transform: none !important;
+  .hao-home--alfolio *,
+  .hao-home--alfolio *::before,
+  .hao-home--alfolio *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
+++ b/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
@@ -1,10 +1,28 @@
 # Homepage Frontend Governance
 
-This document records the production rules for the Hao's Notes homepage after the August 2026 rescue and redesign work.
+This document records the production rules for the Hao's Notes homepage after the August 2026 rescue work and the subsequent return to an al-folio-compatible design direction.
 
 ## Current ownership model
 
-The homepage should use the stable `hao-home--safe hao-home--production` structure in `_pages/about.md`.
+The homepage must keep the native al-folio `layout: about` structure. The page content should live inside the upstream about-page sequence:
+
+1. `.post`
+2. `.post-header`
+3. `.post-title`
+4. `.desc`
+5. `article`
+6. `.profile`
+7. `.clearfix`
+
+The custom homepage content root is now:
+
+```html
+<div class="hao-home hao-home--production hao-home--alfolio">
+```
+
+Do not reintroduce `hao-home--safe` as the active homepage root. That old rescue class hid the native al-folio title/profile surface and pushed the page toward a standalone landing-page shell.
+
+## Active visual stack
 
 The active visual stack is intentionally short:
 
@@ -14,42 +32,49 @@ The active visual stack is intentionally short:
 4. `hao-home-safe.css`
 5. `hao-home-center-fix.css`
 
-`hao-home-safe.css` keeps the homepage out of the legacy al-folio about-page surface. `hao-home-center-fix.css` is the production homepage layer. It owns the page shell, hero, card system, section rhythm, profile card, and responsive behavior.
+`hao-home-safe.css` remains as a historical compatibility layer, but the current homepage should not depend on its old hidden-header behavior. `hao-home-center-fix.css` is now the al-folio-compatible wide homepage layer. It owns only the wider native container, light content cards, section rhythm, and responsive behavior.
 
 Older Mission Log and v6 experiment styles must not be injected or kept as active production CSS.
 
 ## Shell contract
 
-The homepage uses one shared shell token:
+The homepage should follow al-folio's native shell and widen it, rather than replacing it.
 
-- `--hao-page-shell-max`
-- `--hao-page-gutter`
-- `--hao-page-shell`
+Allowed shell tokens:
 
-The navbar container and `.hao-home--production` must both use this same shell. Do not reintroduce competing width variables such as old `--hao-home-shell-*` or `--hao-prod-shell` page-width tokens.
+- `--hao-alfolio-shell-max`
+- `--hao-alfolio-gutter`
+- `--hao-alfolio-shell`
+
+The following elements should share the same widened shell:
+
+- `body:has(.hao-home--alfolio) main > .container`
+- `body:has(.hao-home--alfolio) .navbar > .container`
+- `body:has(.hao-home--alfolio) .navbar > .container-fluid`
+
+Do not reintroduce competing standalone page-width tokens such as `--hao-page-shell`, old `--hao-home-shell-*`, or `--hao-prod-shell`.
 
 ## Navbar brand contract
 
-The homepage must render a real anchor:
+Upstream al-folio intentionally does not render the left navbar brand on the homepage when `page.permalink == '/'`; it renders the brand on secondary pages. For this customized homepage, `_plugins/site_visual_polish.rb` reinserts the same semantic brand pattern used by the upstream secondary-page header:
 
 ```html
-<a class="navbar-brand hao-home-navbar-brand" data-hao-home-brand="true" href="/">Zhihao LIU</a>
+<a class="navbar-brand title font-weight-lighter hao-home-navbar-brand" data-hao-home-brand="true" href="/"><span class="font-weight-bold">Zhihao</span> LIU</a>
 ```
 
-This is injected only on the homepage by `_plugins/site_visual_polish.rb`, because the homepage and secondary pages do not always emit identical navbar-brand markup. Blog and other secondary pages should continue to use the theme's native brand.
+This preserves the original al-folio brand typography rather than fabricating text with CSS. Blog and secondary pages should continue to use the theme's native brand.
 
-The homepage brand must not be fabricated with `::before` content, and it must not be hidden with `font-size: 0`.
+The homepage brand must not be fabricated with `::before` content, hidden with `font-size: 0`, or restyled into a different typography system.
 
 ## Deployment contract
 
 Before a Pages artifact is uploaded, the workflow must verify `_site/index.html` contains:
 
-- `hao-home--safe`
-- `hao-home--production`
-- `Build systems that turn field evidence into usable products.`
-- `hao-home-center-fix.css?v=20260802-shell-navbar-fix`
+- `hao-home--alfolio`
+- `Research records, shipped tools, and field-informed systems.`
+- `hao-home-center-fix.css?v=20260802-alfolio-wide-home`
 - `hao-home-navbar-brand`
-- `Zhihao LIU`
+- `font-weight-bold">Zhihao</span> LIU`
 
 The artifact must not contain deprecated homepage styles such as:
 
@@ -62,19 +87,19 @@ This prevents a green CI run from publishing an artifact that still points to th
 
 The homepage should preserve these rules:
 
-- The homepage navbar brand must remain visible as black `Zhihao LIU`.
-- The homepage and navbar must share one centered page shell.
-- The homepage should keep the current white, purple, and soft-gradient visual language.
-- The homepage should feel like a production personal product surface: composed hero, profile card, current-work cards, systems grid, knowledge workspace, trajectory, and contact block.
-- Legacy about header/profile, legacy news, and legacy announcements should remain disabled on the homepage.
-- The homepage should avoid fixed rails, full-bleed experimental canvases, and oversized hero typography that can clip at common desktop widths.
+- Keep the native al-folio about-page title, subtitle, profile image, article flow, and clearfix structure visible.
+- Widen the original al-folio container instead of rebuilding a standalone landing-page shell.
+- Keep the homepage navbar brand visually aligned with al-folio's original brand style: `<span class="font-weight-bold">Zhihao</span> LIU`.
+- Place `Current work`, `Systems`, `Knowledge`, `Trajectory`, and `Contact` as compatible content modules inside the original layout.
+- Use light cards, subtle borders, and the existing purple accent; avoid heavy hero panels, full-bleed canvases, duplicated profile cards, or product-site visual language.
+- Keep legacy news, latest posts, selected papers, and announcements disabled unless deliberately reintroduced.
 
 ## Change policy
 
 When the homepage visual layer changes:
 
-1. Update `hao-home-center-fix.css` or `hao-home-safe.css`; avoid adding another final CSS layer.
+1. Update `hao-home-center-fix.css` or the homepage markdown; avoid adding another final CSS layer.
 2. Bump `STYLESHEET_VERSION` in `_plugins/site_visual_polish.rb`.
-3. Keep `test/style_contract.js` aligned with the intended production shell.
+3. Keep `test/style_contract.js` aligned with the intended al-folio-compatible shell.
 4. Confirm the workflow artifact check passes before merging.
 5. After merge, verify the live page shows the new stylesheet version in its HTML.

--- a/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
+++ b/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
@@ -1,8 +1,14 @@
 # Homepage Frontend Governance
 
-This document records the production rules for the Hao's Notes homepage after the August 2026 rescue work and the subsequent return to an al-folio-compatible design direction.
+This document records the visual governance rules after the August 2026 homepage rescue and the subsequent decision to restore the site to an al-folio-first baseline.
 
-## Current ownership model
+## Site-wide baseline
+
+The starter should look like upstream al-folio by default. Secondary pages such as Blog, Projects, Repositories, CV, and individual posts must not receive broad custom visual CSS from `_plugins/site_visual_polish.rb`.
+
+The plugin may still perform narrow content fixes, such as the CV title text replacement, but custom visual CSS should be scoped to the homepage only.
+
+## Homepage ownership model
 
 The homepage must keep the native al-folio `layout: about` structure. The page content should live inside the upstream about-page sequence:
 
@@ -14,7 +20,7 @@ The homepage must keep the native al-folio `layout: about` structure. The page c
 6. `.profile`
 7. `.clearfix`
 
-The custom homepage content root is now:
+The custom homepage content root is:
 
 ```html
 <div class="hao-home hao-home--production hao-home--alfolio">
@@ -24,15 +30,12 @@ Do not reintroduce `hao-home--safe` as the active homepage root. That old rescue
 
 ## Active visual stack
 
-The active visual stack is intentionally short:
+The active custom visual stack for rendered pages is intentionally minimal:
 
-1. `site-polish.css`
-2. `site-upgrade.css`
-3. `hao-design.css`
-4. `hao-home-safe.css`
-5. `hao-home-center-fix.css`
+1. Upstream al-folio theme styles from the theme/gem layer.
+2. `hao-home-center-fix.css` on the homepage only.
 
-`hao-home-safe.css` remains as a historical compatibility layer, but the current homepage should not depend on its old hidden-header behavior. `hao-home-center-fix.css` is now the al-folio-compatible wide homepage layer. It owns only the wider native container, light content cards, section rhythm, and responsive behavior.
+`site-polish.css`, `site-upgrade.css`, `hao-design.css`, and `hao-home-safe.css` may remain in the repository for history, but they must not be injected into the blog index or other secondary pages. They should not be treated as active production visual layers.
 
 Older Mission Log and v6 experiment styles must not be injected or kept as active production CSS.
 
@@ -72,16 +75,19 @@ Before a Pages artifact is uploaded, the workflow must verify `_site/index.html`
 
 - `hao-home--alfolio`
 - `Research records, shipped tools, and field-informed systems.`
-- `hao-home-center-fix.css?v=20260802-alfolio-wide-home`
+- `hao-home-center-fix.css?v=20260802-alfolio-baseline`
 - `hao-home-navbar-brand`
 - `font-weight-bold">Zhihao</span> LIU`
 
-The artifact must not contain deprecated homepage styles such as:
+The workflow must also verify `_site/blog/index.html` does not contain active custom visual stylesheets:
 
-- `mission-log-shell-v2.css`
-- `hao-home-v6.css`
+- `site-polish.css`
+- `site-upgrade.css`
+- `hao-design.css`
+- `hao-home-safe.css`
+- `hao-home-center-fix.css`
 
-This prevents a green CI run from publishing an artifact that still points to the wrong homepage shell.
+This prevents a green CI run from keeping the homepage fixed while leaving the blog index visually polluted.
 
 ## Visual contract
 
@@ -91,7 +97,7 @@ The homepage should preserve these rules:
 - Widen the original al-folio container instead of rebuilding a standalone landing-page shell.
 - Keep the homepage navbar brand visually aligned with al-folio's original brand style: `<span class="font-weight-bold">Zhihao</span> LIU`.
 - Place `Current work`, `Systems`, `Knowledge`, `Trajectory`, and `Contact` as compatible content modules inside the original layout.
-- Use light cards, subtle borders, and the existing purple accent; avoid heavy hero panels, full-bleed canvases, duplicated profile cards, or product-site visual language.
+- Use light cards, subtle borders, and the existing theme accent; avoid heavy hero panels, full-bleed canvases, duplicated profile cards, or product-site visual language.
 - Keep legacy news, latest posts, selected papers, and announcements disabled unless deliberately reintroduced.
 
 ## Change policy
@@ -101,5 +107,5 @@ When the homepage visual layer changes:
 1. Update `hao-home-center-fix.css` or the homepage markdown; avoid adding another final CSS layer.
 2. Bump `STYLESHEET_VERSION` in `_plugins/site_visual_polish.rb`.
 3. Keep `test/style_contract.js` aligned with the intended al-folio-compatible shell.
-4. Confirm the workflow artifact check passes before merging.
-5. After merge, verify the live page shows the new stylesheet version in its HTML.
+4. Confirm both homepage and blog artifact checks pass before merging.
+5. After merge, verify the live homepage shows the new stylesheet version and the live blog does not include custom visual CSS links.

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -84,10 +84,10 @@ requireIncludes(
     "hao-design.css",
     "hao-home-safe.css",
     "hao-home-center-fix.css",
-    'STYLESHEET_VERSION = "20260802-shell-navbar-fix"',
-    'HOMEPAGE_BRAND = "Zhihao LIU"',
+    'STYLESHEET_VERSION = "20260802-alfolio-wide-home"',
     "def self.apply_home_navbar_brand(page)",
-    "hao-home-navbar-brand",
+    "navbar-brand title font-weight-lighter hao-home-navbar-brand",
+    "<span class=\"font-weight-bold\">Zhihao</span> LIU",
     "?v=#{STYLESHEET_VERSION}",
   ],
   "Site visual polish plugin",
@@ -100,6 +100,7 @@ requireRegex(
 requireAbsent(
   visualPlugin,
   [
+    'HOMEPAGE_BRAND = "Zhihao LIU"',
     "mission-log-deployments.css",
     "mission-log-records.css",
     "mission-log-observations.css",
@@ -116,54 +117,51 @@ requireAbsent(
 if (!exists("assets/css/site-upgrade.css")) failures.push("Frontend upgrade layer missing: `assets/css/site-upgrade.css`.");
 if (!exists("assets/css/hao-design.css")) failures.push("Hao design system layer missing: `assets/css/hao-design.css`.");
 if (!exists("assets/css/hao-home-safe.css")) failures.push("Safe homepage CSS missing: `assets/css/hao-home-safe.css`.");
-if (!exists("assets/css/hao-home-center-fix.css")) failures.push("Homepage production CSS missing: `assets/css/hao-home-center-fix.css`.");
+if (!exists("assets/css/hao-home-center-fix.css")) failures.push("Homepage al-folio-compatible CSS missing: `assets/css/hao-home-center-fix.css`.");
 
-const homeSafeCss = exists("assets/css/hao-home-safe.css") ? read("assets/css/hao-home-safe.css") : "";
+const homeAlfolioCss = exists("assets/css/hao-home-center-fix.css") ? read("assets/css/hao-home-center-fix.css") : "";
 requireIncludes(
-  homeSafeCss,
+  homeAlfolioCss,
   [
-    ".hao-home--safe",
-    "body:has(.hao-home--safe) .post-title",
-    "body:has(.hao-home--safe) .profile",
-    "overflow-x: clip",
-    "@media (max-width: 900px)",
-    "@media (max-width: 680px)",
-    "prefers-reduced-motion",
-  ],
-  "Safe homepage CSS",
-);
-requireAbsent(homeSafeCss, ["position: fixed", "min-height: 100vh"], "Safe homepage CSS");
-
-const homeProductionCss = exists("assets/css/hao-home-center-fix.css") ? read("assets/css/hao-home-center-fix.css") : "";
-requireIncludes(
-  homeProductionCss,
-  [
-    "Production homepage shell and navbar hardening layer",
-    "--hao-page-shell-max: 76rem",
-    "--hao-page-shell: min(calc(100vw",
+    "al-folio-compatible wide homepage layer",
+    "--hao-alfolio-shell-max: 72rem",
+    "body:has(.hao-home--alfolio) main > .container",
+    "body:has(.hao-home--alfolio) .navbar > .container",
+    "display: revert !important",
     ".hao-home-navbar-brand",
-    ".navbar .navbar-brand:not(.hao-home-navbar-brand)",
-    "The homepage brand is a real injected anchor",
-    ".hao-prod-hero",
-    ".hao-prod-work-grid",
-    ".hao-prod-knowledge-grid",
-    ".hao-prod-timeline",
-    "@media (max-width: 1100px)",
-    "@media (max-width: 900px)",
-    "@media (max-width: 680px)",
+    ".hao-home--alfolio",
+    ".hao-home-intro",
+    ".hao-home-section",
+    ".hao-home-knowledge-grid",
+    "@media (max-width: 992px)",
+    "@media (max-width: 760px)",
   ],
-  "Homepage production CSS",
+  "Homepage al-folio-compatible CSS",
 );
-requireAbsent(homeProductionCss, ['content: "Zhihao LIU"', "font-size: 0 !important", "--hao-home-shell", "--hao-prod-shell:"], "Homepage production CSS");
+requireAbsent(
+  homeAlfolioCss,
+  [
+    'content: "Zhihao LIU"',
+    "font-size: 0 !important",
+    "--hao-page-shell",
+    "--hao-prod-shell",
+    ".hao-prod-hero",
+    ".hao-prod-profile",
+    ".navbar .navbar-brand:not(.hao-home-navbar-brand)",
+    "position: fixed",
+  ],
+  "Homepage al-folio-compatible CSS",
+);
 
 const workflow = read(".github/workflows/deploy.yml");
 requireIncludes(
   workflow,
   [
-    "hao-home--production",
-    "hao-home-center-fix.css?v=20260802-shell-navbar-fix",
+    "hao-home--alfolio",
+    "Research records, shipped tools, and field-informed systems.",
+    "hao-home-center-fix.css?v=20260802-alfolio-wide-home",
     "hao-home-navbar-brand",
-    "Zhihao LIU",
+    'font-weight-bold">Zhihao</span> LIU',
   ],
   "Deploy workflow homepage artifact guard",
 );
@@ -172,32 +170,33 @@ const aboutPage = read("_pages/about.md");
 requireIncludes(
   aboutPage,
   [
-    "hao-home--safe hao-home--production",
-    "Build systems that turn field evidence into usable products.",
-    "Independent Builder · Climate · Geospatial · AI",
-    "Explore current work",
-    "Active tracks, organized as working lanes.",
-    "Selected systems",
-    "Knowledge work",
-    "Research records and field notes in one workspace.",
-    "Career trajectory",
-    "hao-prod-contact",
+    "hao-home--production hao-home--alfolio",
+    "Climate data · Geoscience evidence · AI tools",
+    "Research records, shipped tools, and field-informed systems.",
+    "Current work",
+    "Systems",
+    "Knowledge",
+    "Trajectory",
+    "Contact",
+    "hao-home-contact",
   ],
-  "Production homepage",
+  "al-folio-compatible homepage",
 );
 requireAbsent(
   aboutPage,
   [
+    "hao-home--safe",
     "hao-home--v6",
-    "Building small data systems for climate, geoscience, and personal productivity.",
-    "Climate data, geoscience evidence, and small tools.",
+    "hao-prod-",
+    "Build systems that turn field evidence into usable products.",
+    "Independent Builder · Climate · Geospatial · AI",
     "mission-log-home--product",
     "mission-page-rail",
     "operations-console",
-    "hao-safe-section",
   ],
-  "Production homepage",
+  "al-folio-compatible homepage",
 );
+requireRegex(aboutPage, /^layout:\s*about\b/m, "Homepage must keep al-folio `layout: about`.");
 requireRegex(aboutPage, /^news:\s*false\b/m, "Hao homepage must keep legacy `news` disabled.");
 requireRegex(aboutPage, /^\s*enabled:\s*false\b/m, "Hao homepage must keep legacy announcements disabled.");
 

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -79,27 +79,27 @@ const visualPlugin = read("_plugins/site_visual_polish.rb");
 requireIncludes(
   visualPlugin,
   [
-    "site-polish.css",
-    "site-upgrade.css",
-    "hao-design.css",
-    "hao-home-safe.css",
+    "HOMEPAGE_STYLESHEETS",
     "hao-home-center-fix.css",
-    'STYLESHEET_VERSION = "20260802-alfolio-wide-home"',
+    'STYLESHEET_VERSION = "20260802-alfolio-baseline"',
     "def self.apply_home_navbar_brand(page)",
     "navbar-brand title font-weight-lighter hao-home-navbar-brand",
     "<span class=\"font-weight-bold\">Zhihao</span> LIU",
+    "def self.apply_homepage_stylesheet(page)",
     "?v=#{STYLESHEET_VERSION}",
   ],
   "Site visual polish plugin",
 );
-requireRegex(
-  visualPlugin,
-  /"hao-home-safe\.css",\s*"hao-home-center-fix\.css"/m,
-  "Final homepage stylesheets must load in the order `hao-home-safe.css` then `hao-home-center-fix.css`.",
-);
 requireAbsent(
   visualPlugin,
   [
+    "TARGET_PAGES",
+    "TARGET_URLS",
+    "TARGET_URL_PREFIXES",
+    "site-polish.css",
+    "site-upgrade.css",
+    "hao-design.css",
+    "hao-home-safe.css",
     'HOMEPAGE_BRAND = "Zhihao LIU"',
     "mission-log-deployments.css",
     "mission-log-records.css",
@@ -114,16 +114,13 @@ requireAbsent(
   "Site visual polish plugin",
 );
 
-if (!exists("assets/css/site-upgrade.css")) failures.push("Frontend upgrade layer missing: `assets/css/site-upgrade.css`.");
-if (!exists("assets/css/hao-design.css")) failures.push("Hao design system layer missing: `assets/css/hao-design.css`.");
-if (!exists("assets/css/hao-home-safe.css")) failures.push("Safe homepage CSS missing: `assets/css/hao-home-safe.css`.");
 if (!exists("assets/css/hao-home-center-fix.css")) failures.push("Homepage al-folio-compatible CSS missing: `assets/css/hao-home-center-fix.css`.");
 
 const homeAlfolioCss = exists("assets/css/hao-home-center-fix.css") ? read("assets/css/hao-home-center-fix.css") : "";
 requireIncludes(
   homeAlfolioCss,
   [
-    "al-folio-compatible wide homepage layer",
+    "al-folio baseline homepage enhancement",
     "--hao-alfolio-shell-max: 72rem",
     "body:has(.hao-home--alfolio) main > .container",
     "body:has(.hao-home--alfolio) .navbar > .container",
@@ -159,9 +156,11 @@ requireIncludes(
   [
     "hao-home--alfolio",
     "Research records, shipped tools, and field-informed systems.",
-    "hao-home-center-fix.css?v=20260802-alfolio-wide-home",
+    "hao-home-center-fix.css?v=20260802-alfolio-baseline",
     "hao-home-navbar-brand",
     'font-weight-bold">Zhihao</span> LIU',
+    "Verify secondary pages keep al-folio baseline",
+    "site-polish.css|site-upgrade.css|hao-design.css|hao-home-safe.css|hao-home-center-fix.css",
   ],
   "Deploy workflow homepage artifact guard",
 );


### PR DESCRIPTION
## Summary
- restore the site to an al-folio-first visual baseline
- stop injecting broad custom visual CSS into Blog, Projects, Repositories, CV, and secondary pages
- scope custom visual CSS to the homepage only via `HOMEPAGE_STYLESHEETS = ["hao-home-center-fix.css"]`
- keep the homepage on native `layout: about` with `.post-header`, `.post-title`, `.desc`, `article`, `.profile`, and `.clearfix` visible
- widen only the native al-folio homepage shell instead of rebuilding a standalone landing page
- keep `Current work`, `Systems`, `Knowledge`, `Trajectory`, and `Contact` as lightweight content modules inside the original about layout
- reinsert the homepage navbar brand using upstream-style markup: `navbar-brand title font-weight-lighter` + `<span class="font-weight-bold">Zhihao</span> LIU`
- bump stylesheet cache version to `20260802-alfolio-baseline`
- add artifact checks that the homepage receives the enhancement while the blog index does not receive custom visual CSS

## Why
The previous redesigns moved too far away from al-folio. The user wants the original al-folio design restored as much as possible, because even the blog secondary page had become uglier than upstream al-folio. This PR treats al-folio as the visual baseline and makes the homepage the only customized surface.

## Verification
- frontend contract should pass
- Prettier should pass
- Ruby syntax check should pass
- Jekyll production build should pass
- homepage artifact check should pass
- blog baseline artifact check should pass
- PurgeCSS should pass
- Pages artifact upload should pass

## Review focus
- Blog index should look much closer to upstream al-folio again
- Secondary pages should not contain `site-polish.css`, `site-upgrade.css`, `hao-design.css`, `hao-home-safe.css`, or `hao-home-center-fix.css`
- Homepage should preserve al-folio's about-page grammar while being slightly wider
- Homepage brand should match al-folio's original typography pattern