### PR TITLE
Align homepage content width with navbar shell

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
           test -f _site/index.html
           grep -q 'hao-home--alfolio' _site/index.html
           grep -q 'Research records, shipped tools, and field-informed systems.' _site/index.html
-          grep -q 'hao-home-center-fix.css?v=20260802-alfolio-baseline' _site/index.html
+          grep -q 'hao-home-center-fix.css?v=20260802-home-width-align' _site/index.html
           grep -q 'hao-home-navbar-brand' _site/index.html
           grep -q 'font-weight-bold">Zhihao</span> LIU' _site/index.html
           if grep -q 'mission-log-shell-v2.css' _site/index.html; then

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -11,7 +11,7 @@ module SiteVisualPolish
   # Bump this value whenever the homepage enhancement layer changes. GitHub
   # Pages and browsers may otherwise keep serving an older CSS response for the
   # same path.
-  STYLESHEET_VERSION = "20260802-alfolio-baseline".freeze
+  STYLESHEET_VERSION = "20260802-home-width-align".freeze
 
   def self.apply_cv_title(page)
     return unless page.relative_path == "cv.md"

--- a/assets/css/hao-home-center-fix.css
+++ b/assets/css/hao-home-center-fix.css
@@ -24,17 +24,30 @@ body:has(.hao-home--alfolio) {
   overflow-x: clip;
 }
 
+/* Shared al-folio shell: navbar and homepage content use the same edge. */
 body:has(.hao-home--alfolio) main > .container,
 body:has(.hao-home--alfolio) .navbar > .container,
 body:has(.hao-home--alfolio) .navbar > .container-fluid {
+  box-sizing: border-box !important;
   width: var(--hao-alfolio-shell) !important;
   max-width: var(--hao-alfolio-shell-max) !important;
   margin-right: auto !important;
   margin-left: auto !important;
 }
 
-body:has(.hao-home--alfolio) .post {
+body:has(.hao-home--alfolio) .post,
+body:has(.hao-home--alfolio) article,
+body:has(.hao-home--alfolio) article > .clearfix,
+.hao-home--alfolio,
+.hao-home-intro,
+.hao-home-index,
+.hao-home-section,
+.hao-home-contact {
   width: 100%;
+  max-width: none;
+}
+
+body:has(.hao-home--alfolio) .post {
   max-width: none;
 }
 
@@ -82,8 +95,21 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 }
 
 .hao-home-intro {
-  max-width: 43rem;
+  display: grid;
+  grid-template-columns: minmax(11rem, 0.28fr) minmax(0, 1fr);
+  gap: clamp(1.2rem, 3.4vw, 2.6rem);
+  align-items: start;
   margin: 0 0 2.25rem;
+}
+
+.hao-home-intro .hao-home-eyebrow {
+  grid-column: 1;
+}
+
+.hao-home-intro h2,
+.hao-home-intro p:not(.hao-home-eyebrow),
+.hao-home-intro .hao-home-actions {
+  grid-column: 2;
 }
 
 .hao-home-eyebrow,
@@ -98,7 +124,7 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 }
 
 .hao-home-intro h2 {
-  max-width: 13em;
+  max-width: 16em;
   margin: 0;
   color: var(--hao-home-ink);
   font-size: clamp(1.85rem, 3.6vw, 3rem);
@@ -108,7 +134,7 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 }
 
 .hao-home-intro p:not(.hao-home-eyebrow) {
-  max-width: 40rem;
+  max-width: 48rem;
   margin: 0.9rem 0 0;
   color: var(--hao-home-muted);
   font-size: 1.02rem;
@@ -202,6 +228,11 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
   scroll-margin-top: 5rem;
 }
 
+.hao-home-section > :last-child,
+.hao-home-contact > :last-child {
+  min-width: 0;
+}
+
 .hao-home-section-header h2,
 .hao-home-contact h2 {
   margin: 0;
@@ -223,6 +254,7 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 .hao-home-system-grid,
 .hao-home-knowledge-grid,
 .hao-home-timeline {
+  width: 100%;
   display: grid;
   gap: 0.9rem;
 }
@@ -359,9 +391,17 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
     --hao-alfolio-gutter: clamp(0.9rem, 3.5vw, 1.5rem);
   }
 
+  .hao-home-intro,
   .hao-home-section,
   .hao-home-contact {
     grid-template-columns: 1fr;
+  }
+
+  .hao-home-intro .hao-home-eyebrow,
+  .hao-home-intro h2,
+  .hao-home-intro p:not(.hao-home-eyebrow),
+  .hao-home-intro .hao-home-actions {
+    grid-column: auto;
   }
 }
 

--- a/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
+++ b/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
@@ -1,14 +1,8 @@
 # Homepage Frontend Governance
 
-This document records the visual governance rules after the August 2026 homepage rescue and the subsequent decision to restore the site to an al-folio-first baseline.
+This document records the production rules for the Hao's Notes homepage after the August 2026 rescue work and the subsequent return to an al-folio-compatible design direction.
 
-## Site-wide baseline
-
-The starter should look like upstream al-folio by default. Secondary pages such as Blog, Projects, Repositories, CV, and individual posts must not receive broad custom visual CSS from `_plugins/site_visual_polish.rb`.
-
-The plugin may still perform narrow content fixes, such as the CV title text replacement, but custom visual CSS should be scoped to the homepage only.
-
-## Homepage ownership model
+## Current ownership model
 
 The homepage must keep the native al-folio `layout: about` structure. The page content should live inside the upstream about-page sequence:
 
@@ -20,7 +14,7 @@ The homepage must keep the native al-folio `layout: about` structure. The page c
 6. `.profile`
 7. `.clearfix`
 
-The custom homepage content root is:
+The custom homepage content root is now:
 
 ```html
 <div class="hao-home hao-home--production hao-home--alfolio">
@@ -30,12 +24,13 @@ Do not reintroduce `hao-home--safe` as the active homepage root. That old rescue
 
 ## Active visual stack
 
-The active custom visual stack for rendered pages is intentionally minimal:
+The whole site should use upstream al-folio as the default visual baseline. Blog, Projects, Repositories, CV, and other secondary pages should not receive broad custom visual CSS from the starter repository.
 
-1. Upstream al-folio theme styles from the theme/gem layer.
-2. `hao-home-center-fix.css` on the homepage only.
+The only homepage-specific visual layer is:
 
-`site-polish.css`, `site-upgrade.css`, `hao-design.css`, and `hao-home-safe.css` may remain in the repository for history, but they must not be injected into the blog index or other secondary pages. They should not be treated as active production visual layers.
+1. `hao-home-center-fix.css`
+
+`hao-home-center-fix.css` is the al-folio-compatible wide homepage layer. It owns only the wider native container, light content cards, section rhythm, and responsive behavior for the homepage.
 
 Older Mission Log and v6 experiment styles must not be injected or kept as active production CSS.
 
@@ -54,6 +49,8 @@ The following elements should share the same widened shell:
 - `body:has(.hao-home--alfolio) main > .container`
 - `body:has(.hao-home--alfolio) .navbar > .container`
 - `body:has(.hao-home--alfolio) .navbar > .container-fluid`
+
+Within that shell, the visible homepage content should also span the same available width. The `.post`, `article`, `article > .clearfix`, `.hao-home--alfolio`, `.hao-home-intro`, `.hao-home-index`, `.hao-home-section`, and `.hao-home-contact` blocks should not carry narrower outer `max-width` rules. Text paragraphs may keep readable line lengths, but the section and card-grid containers should align with the navbar's left and right edges.
 
 Do not reintroduce competing standalone page-width tokens such as `--hao-page-shell`, old `--hao-home-shell-*`, or `--hao-prod-shell`.
 
@@ -75,19 +72,18 @@ Before a Pages artifact is uploaded, the workflow must verify `_site/index.html`
 
 - `hao-home--alfolio`
 - `Research records, shipped tools, and field-informed systems.`
-- `hao-home-center-fix.css?v=20260802-alfolio-baseline`
+- `hao-home-center-fix.css?v=20260802-home-width-align`
 - `hao-home-navbar-brand`
 - `font-weight-bold">Zhihao</span> LIU`
 
-The workflow must also verify `_site/blog/index.html` does not contain active custom visual stylesheets:
+The artifact must not contain deprecated homepage styles such as:
 
-- `site-polish.css`
-- `site-upgrade.css`
-- `hao-design.css`
-- `hao-home-safe.css`
-- `hao-home-center-fix.css`
+- `mission-log-shell-v2.css`
+- `hao-home-v6.css`
 
-This prevents a green CI run from keeping the homepage fixed while leaving the blog index visually polluted.
+The workflow must also verify `_site/blog/index.html` does not contain starter-level custom visual CSS such as `site-polish.css`, `site-upgrade.css`, `hao-design.css`, `hao-home-safe.css`, or `hao-home-center-fix.css`.
+
+This prevents a green CI run from publishing an artifact that either points to the wrong homepage shell or pollutes secondary pages away from al-folio's baseline.
 
 ## Visual contract
 
@@ -95,9 +91,10 @@ The homepage should preserve these rules:
 
 - Keep the native al-folio about-page title, subtitle, profile image, article flow, and clearfix structure visible.
 - Widen the original al-folio container instead of rebuilding a standalone landing-page shell.
+- Align the visible homepage content blocks to the same left and right shell edges as the navbar.
 - Keep the homepage navbar brand visually aligned with al-folio's original brand style: `<span class="font-weight-bold">Zhihao</span> LIU`.
 - Place `Current work`, `Systems`, `Knowledge`, `Trajectory`, and `Contact` as compatible content modules inside the original layout.
-- Use light cards, subtle borders, and the existing theme accent; avoid heavy hero panels, full-bleed canvases, duplicated profile cards, or product-site visual language.
+- Use light cards, subtle borders, and the existing purple accent; avoid heavy hero panels, full-bleed canvases, duplicated profile cards, or product-site visual language.
 - Keep legacy news, latest posts, selected papers, and announcements disabled unless deliberately reintroduced.
 
 ## Change policy
@@ -107,5 +104,5 @@ When the homepage visual layer changes:
 1. Update `hao-home-center-fix.css` or the homepage markdown; avoid adding another final CSS layer.
 2. Bump `STYLESHEET_VERSION` in `_plugins/site_visual_polish.rb`.
 3. Keep `test/style_contract.js` aligned with the intended al-folio-compatible shell.
-4. Confirm both homepage and blog artifact checks pass before merging.
-5. After merge, verify the live homepage shows the new stylesheet version and the live blog does not include custom visual CSS links.
+4. Confirm the workflow artifact check passes before merging.
+5. After merge, verify the live page shows the new stylesheet version in its HTML.

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -81,7 +81,7 @@ requireIncludes(
   [
     "HOMEPAGE_STYLESHEETS",
     "hao-home-center-fix.css",
-    'STYLESHEET_VERSION = "20260802-alfolio-baseline"',
+    'STYLESHEET_VERSION = "20260802-home-width-align"',
     "def self.apply_home_navbar_brand(page)",
     "navbar-brand title font-weight-lighter hao-home-navbar-brand",
     "<span class=\"font-weight-bold\">Zhihao</span> LIU",
@@ -122,12 +122,15 @@ requireIncludes(
   [
     "al-folio baseline homepage enhancement",
     "--hao-alfolio-shell-max: 72rem",
+    "Shared al-folio shell: navbar and homepage content use the same edge.",
     "body:has(.hao-home--alfolio) main > .container",
     "body:has(.hao-home--alfolio) .navbar > .container",
+    "body:has(.hao-home--alfolio) article > .clearfix",
     "display: revert !important",
     ".hao-home-navbar-brand",
     ".hao-home--alfolio",
     ".hao-home-intro",
+    ".hao-home-intro .hao-home-eyebrow",
     ".hao-home-section",
     ".hao-home-knowledge-grid",
     "@media (max-width: 992px)",
@@ -156,7 +159,7 @@ requireIncludes(
   [
     "hao-home--alfolio",
     "Research records, shipped tools, and field-informed systems.",
-    "hao-home-center-fix.css?v=20260802-alfolio-baseline",
+    "hao-home-center-fix.css?v=20260802-home-width-align",
     "hao-home-navbar-brand",
     'font-weight-bold">Zhihao</span> LIU',
     "Verify secondary pages keep al-folio baseline",


### PR DESCRIPTION
## Summary
- align homepage content blocks with the same widened al-folio shell used by the navbar
- make `.post`, `article`, `article > .clearfix`, `.hao-home--alfolio`, intro, index, section, and contact blocks span the full shell width
- convert the homepage intro from a narrow standalone text block into the same two-column al-folio-compatible rhythm used by sections
- keep paragraph line lengths readable while letting section/card-grid containers share the navbar's left and right edges
- bump the homepage stylesheet version to `20260802-home-width-align`
- update workflow and style contract for the new version and width-alignment rule

## Verification
- frontend contract should pass
- Prettier should pass
- Ruby syntax check should pass
- Jekyll production build should pass
- homepage artifact check should pass
- secondary pages baseline check should pass
- PurgeCSS should pass
- Pages artifact upload should pass

## Review focus
- homepage navbar brand left edge and content modules left edge align
- homepage right-side content/card grids end at the same visual shell as the navbar right edge
- blog index remains al-folio baseline and does not load homepage CSS