### PR TITLE
Fix homepage shell width and coordinate the banner layout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,8 +79,9 @@ jobs:
           set -euo pipefail
           test -f _site/index.html
           grep -q 'hao-home--alfolio' _site/index.html
+          grep -q 'hao-home-page' _site/index.html
           grep -q 'Research records, shipped tools, and field-informed systems.' _site/index.html
-          grep -q 'hao-home-center-fix.css?v=20260802-home-width-align' _site/index.html
+          grep -q 'hao-home-center-fix.css?v=20260803-shell-banner-grid' _site/index.html
           grep -q 'hao-home-navbar-brand' _site/index.html
           grep -q 'font-weight-bold">Zhihao</span> LIU' _site/index.html
           if grep -q 'mission-log-shell-v2.css' _site/index.html; then

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -11,7 +11,7 @@ module SiteVisualPolish
   # Bump this value whenever the homepage enhancement layer changes. GitHub
   # Pages and browsers may otherwise keep serving an older CSS response for the
   # same path.
-  STYLESHEET_VERSION = "20260802-home-width-align".freeze
+  STYLESHEET_VERSION = "20260803-shell-banner-grid".freeze
 
   def self.apply_cv_title(page)
     return unless page.relative_path == "cv.md"
@@ -24,6 +24,17 @@ module SiteVisualPolish
 
   def self.home_page?(page)
     page.relative_path == "_pages/about.md" || page.url.to_s == "/"
+  end
+
+  def self.apply_home_body_class(page)
+    return unless home_page?(page)
+    return unless page.output.include?("hao-home--alfolio")
+    return if page.output.include?("hao-home-page")
+
+    # Give the rendered homepage a stable, explicit scope. This avoids relying
+    # on :has(), keeps PurgeCSS selectors deterministic, and lets the stylesheet
+    # target the theme's real body-level content container.
+    page.output = page.output.sub('<body class="', '<body class="hao-home-page ')
   end
 
   def self.apply_home_navbar_brand(page)
@@ -62,6 +73,7 @@ end
 [:pages, :documents].each do |hook_owner|
   Jekyll::Hooks.register hook_owner, :post_render do |page|
     SiteVisualPolish.apply_cv_title(page)
+    SiteVisualPolish.apply_home_body_class(page)
     SiteVisualPolish.apply_home_navbar_brand(page)
     SiteVisualPolish.apply_homepage_stylesheet(page)
   end

--- a/assets/css/hao-home-center-fix.css
+++ b/assets/css/hao-home-center-fix.css
@@ -1,16 +1,16 @@
 /*
  * al-folio baseline homepage enhancement
  *
- * The whole site should look like upstream al-folio by default. This single
- * homepage-only layer widens the native about-page shell and adds lightweight
- * content modules inside the original .post / article / clearfix flow. It does
- * not restyle Blog, Projects, Repositories, CV, or secondary pages.
+ * The homepage keeps the upstream about-page DOM, but gives it one explicit
+ * production shell and one coordinated banner grid. Secondary pages remain on
+ * the native al-folio baseline.
  */
 
 :root {
-  --hao-alfolio-shell-max: 72rem;
-  --hao-alfolio-gutter: clamp(1rem, 4vw, 2rem);
+  --hao-alfolio-shell-max: 84rem;
+  --hao-alfolio-gutter: clamp(1rem, 3vw, 2.5rem);
   --hao-alfolio-shell: min(calc(100% - var(--hao-alfolio-gutter) - var(--hao-alfolio-gutter)), var(--hao-alfolio-shell-max));
+  --hao-home-profile-width: clamp(17.5rem, 24vw, 20rem);
   --hao-home-ink: var(--global-text-color, #111827);
   --hao-home-muted: var(--global-text-color-light, #6b7280);
   --hao-home-accent: var(--global-theme-color, #b80fb8);
@@ -19,15 +19,18 @@
   --hao-home-soft: color-mix(in srgb, var(--hao-home-accent) 5%, var(--global-bg-color, #ffffff));
 }
 
-html:has(.hao-home--alfolio),
-body:has(.hao-home--alfolio) {
+.hao-home-page {
   overflow-x: clip;
 }
 
-/* Shared al-folio shell: navbar and homepage content use the same edge. */
-body:has(.hao-home--alfolio) main > .container,
-body:has(.hao-home--alfolio) .navbar > .container,
-body:has(.hao-home--alfolio) .navbar > .container-fluid {
+/*
+ * One measurable shell for both surfaces. The theme renders the page container
+ * as body > .container[role="main"] and the navigation shell as #navbar >
+ * .container; target those real nodes instead of an assumed <main> wrapper.
+ */
+.hao-home-page > .container[role="main"],
+.hao-home-page #navbar > .container,
+.hao-home-page #navbar > .container-fluid {
   box-sizing: border-box !important;
   width: var(--hao-alfolio-shell) !important;
   max-width: var(--hao-alfolio-shell-max) !important;
@@ -35,9 +38,9 @@ body:has(.hao-home--alfolio) .navbar > .container-fluid {
   margin-left: auto !important;
 }
 
-body:has(.hao-home--alfolio) .post,
-body:has(.hao-home--alfolio) article,
-body:has(.hao-home--alfolio) article > .clearfix,
+.hao-home-page .post,
+.hao-home-page .post > article,
+.hao-home-page .post > article > .clearfix,
 .hao-home--alfolio,
 .hao-home-intro,
 .hao-home-index,
@@ -47,45 +50,94 @@ body:has(.hao-home--alfolio) article > .clearfix,
   max-width: none;
 }
 
-body:has(.hao-home--alfolio) .post {
-  max-width: none;
-}
-
 /* Keep the native al-folio about-page surface visible. */
-body:has(.hao-home--alfolio) .post > header,
-body:has(.hao-home--alfolio) .post-header,
-body:has(.hao-home--alfolio) .post-title,
-body:has(.hao-home--alfolio) .post-description,
-body:has(.hao-home--alfolio) .profile {
-  display: revert !important;
+.hao-home-page .post > header,
+.hao-home-page .post-header,
+.hao-home-page .post-title,
+.hao-home-page .post-description,
+.hao-home-page .profile {
   visibility: visible !important;
   opacity: 1 !important;
 }
 
-body:has(.hao-home--alfolio) .post-header {
-  margin-bottom: 1.75rem;
+/*
+ * Coordinated banner: native title and custom introduction form one left-hand
+ * narrative, while the native profile occupies the right column. display:
+ * contents keeps the upstream article/clearfix markup without adding a second
+ * landing-page shell.
+ */
+.hao-home-page .post {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--hao-home-profile-width);
+  grid-template-areas:
+    "header profile"
+    "intro profile"
+    "index index";
+  column-gap: clamp(2rem, 5vw, 5rem);
+  align-items: start;
 }
 
-body:has(.hao-home--alfolio) .desc {
+.hao-home-page .post > .post-header {
+  grid-area: header;
+  min-width: 0;
+  margin: 0;
+}
+
+.hao-home-page .post > article,
+.hao-home-page .post > article > .clearfix,
+.hao-home-page .hao-home--alfolio {
+  display: contents;
+}
+
+.hao-home-page .post > article > .profile {
+  grid-area: profile;
+  float: none !important;
+  width: 100% !important;
+  max-width: var(--hao-home-profile-width) !important;
+  margin: 0 !important;
+  justify-self: end;
+}
+
+.hao-home-page .post > article > .profile figure,
+.hao-home-page .post > article > .profile picture {
+  display: block;
+  width: 100%;
+  margin: 0;
+}
+
+.hao-home-page .post > article > .profile img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.hao-home-page .post > article > .profile .more-info {
+  margin-top: 0.75rem;
+  color: var(--hao-home-ink);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.hao-home-page .post > article > .profile .more-info p {
+  margin: 0;
+}
+
+.hao-home-page .desc {
   max-width: 42rem;
+  margin-bottom: 0;
 }
 
 /* Homepage brand: same semantic class stack as the upstream al-folio header. */
-body:has(.hao-home--alfolio) .hao-home-navbar-brand {
+.hao-home-page .hao-home-navbar-brand {
   display: inline-block !important;
   text-decoration: none !important;
   visibility: visible !important;
   opacity: 1 !important;
 }
 
-body:has(.hao-home--alfolio) .hao-home-navbar-brand::before,
-body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
+.hao-home-page .hao-home-navbar-brand::before,
+.hao-home-page .hao-home-navbar-brand::after {
   content: none !important;
-}
-
-.hao-home--alfolio {
-  clear: both;
-  margin-top: 1.25rem;
 }
 
 .hao-home--alfolio *,
@@ -95,26 +147,16 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 }
 
 .hao-home-intro {
-  display: grid;
-  grid-template-columns: minmax(11rem, 0.28fr) minmax(0, 1fr);
-  gap: clamp(1.2rem, 3.4vw, 2.6rem);
-  align-items: start;
-  margin: 0 0 2.25rem;
-}
-
-.hao-home-intro .hao-home-eyebrow {
-  grid-column: 1;
-}
-
-.hao-home-intro h2,
-.hao-home-intro p:not(.hao-home-eyebrow),
-.hao-home-intro .hao-home-actions {
-  grid-column: 2;
+  grid-area: intro;
+  display: block;
+  min-width: 0;
+  max-width: 50rem;
+  margin: clamp(1.75rem, 3.2vw, 2.8rem) 0 0;
 }
 
 .hao-home-eyebrow,
 .hao-home-card-label {
-  margin: 0 0 0.45rem;
+  margin: 0 0 0.55rem;
   color: var(--hao-home-accent);
   font-size: 0.72rem;
   font-weight: 700;
@@ -124,21 +166,21 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 }
 
 .hao-home-intro h2 {
-  max-width: 16em;
+  max-width: 15em;
   margin: 0;
   color: var(--hao-home-ink);
-  font-size: clamp(1.85rem, 3.6vw, 3rem);
+  font-size: clamp(2.15rem, 4.1vw, 3.65rem);
   font-weight: 500;
-  letter-spacing: -0.045em;
-  line-height: 1.05;
+  letter-spacing: -0.05em;
+  line-height: 1.02;
 }
 
-.hao-home-intro p:not(.hao-home-eyebrow) {
-  max-width: 48rem;
-  margin: 0.9rem 0 0;
+.hao-home-intro > p:not(.hao-home-eyebrow) {
+  max-width: 46rem;
+  margin: 1.15rem 0 0;
   color: var(--hao-home-muted);
   font-size: 1.02rem;
-  line-height: 1.7;
+  line-height: 1.72;
 }
 
 .hao-home-actions,
@@ -151,7 +193,7 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 }
 
 .hao-home-actions {
-  margin-top: 1.15rem;
+  margin-top: 1.2rem;
 }
 
 .hao-home-button,
@@ -191,13 +233,13 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 }
 
 .hao-home-index {
-  clear: both;
+  grid-area: index;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem 0.7rem;
+  gap: 0.4rem 0.85rem;
   align-items: center;
-  margin: 2rem 0 0;
-  padding: 0.85rem 0;
+  margin: clamp(2.25rem, 5vw, 4rem) 0 0;
+  padding: 0.9rem 0;
   border-top: 1px solid var(--hao-home-line);
   border-bottom: 1px solid var(--hao-home-line);
 }
@@ -219,11 +261,12 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 
 .hao-home-section,
 .hao-home-contact {
+  grid-column: 1 / -1;
   clear: both;
   display: grid;
-  grid-template-columns: minmax(11rem, 0.28fr) minmax(0, 1fr);
-  gap: clamp(1.2rem, 3.4vw, 2.6rem);
-  padding: clamp(2rem, 4.5vw, 3.4rem) 0;
+  grid-template-columns: minmax(12rem, 0.24fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  padding: clamp(2.25rem, 5vw, 4rem) 0;
   border-bottom: 1px solid var(--hao-home-line);
   scroll-margin-top: 5rem;
 }
@@ -254,8 +297,8 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
 .hao-home-system-grid,
 .hao-home-knowledge-grid,
 .hao-home-timeline {
-  width: 100%;
   display: grid;
+  width: 100%;
   gap: 0.9rem;
 }
 
@@ -389,27 +432,44 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
   :root {
     --hao-alfolio-shell-max: 64rem;
     --hao-alfolio-gutter: clamp(0.9rem, 3.5vw, 1.5rem);
+    --hao-home-profile-width: min(22rem, 100%);
   }
 
-  .hao-home-intro,
+  .hao-home-page .post {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "header"
+      "intro"
+      "profile"
+      "index";
+  }
+
+  .hao-home-page .post > article > .profile {
+    width: min(100%, 22rem) !important;
+    max-width: 22rem !important;
+    margin-top: 2rem !important;
+    justify-self: start;
+  }
+
+  .hao-home-intro {
+    max-width: 46rem;
+  }
+
   .hao-home-section,
   .hao-home-contact {
     grid-template-columns: 1fr;
   }
-
-  .hao-home-intro .hao-home-eyebrow,
-  .hao-home-intro h2,
-  .hao-home-intro p:not(.hao-home-eyebrow),
-  .hao-home-intro .hao-home-actions {
-    grid-column: auto;
-  }
 }
 
 @media (max-width: 760px) {
-  body:has(.hao-home--alfolio) main > .container,
-  body:has(.hao-home--alfolio) .navbar > .container,
-  body:has(.hao-home--alfolio) .navbar > .container-fluid {
+  .hao-home-page > .container[role="main"],
+  .hao-home-page #navbar > .container,
+  .hao-home-page #navbar > .container-fluid {
     width: min(calc(100% - 1.25rem), 64rem) !important;
+  }
+
+  .hao-home-page .post > article > .profile {
+    width: 100% !important;
   }
 
   .hao-home-card-grid,
@@ -420,7 +480,7 @@ body:has(.hao-home--alfolio) .hao-home-navbar-brand::after {
   }
 
   .hao-home-intro h2 {
-    font-size: clamp(1.7rem, 8vw, 2.45rem);
+    font-size: clamp(1.85rem, 9vw, 2.7rem);
   }
 }
 

--- a/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
+++ b/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
@@ -14,11 +14,13 @@ The homepage must keep the native al-folio `layout: about` structure. The page c
 6. `.profile`
 7. `.clearfix`
 
-The custom homepage content root is now:
+The custom homepage content root is:
 
 ```html
 <div class="hao-home hao-home--production hao-home--alfolio">
 ```
+
+The rendered homepage body receives the explicit class `hao-home-page` from `_plugins/site_visual_polish.rb`. Homepage CSS must use that class as its scope. Do not rely on `body:has(...)`: the explicit body class is easier to audit, survives CSS processing predictably, and exposes the real theme container without affecting secondary pages.
 
 Do not reintroduce `hao-home--safe` as the active homepage root. That old rescue class hid the native al-folio title/profile surface and pushed the page toward a standalone landing-page shell.
 
@@ -30,29 +32,47 @@ The only homepage-specific visual layer is:
 
 1. `hao-home-center-fix.css`
 
-`hao-home-center-fix.css` is the al-folio-compatible wide homepage layer. It owns only the wider native container, light content cards, section rhythm, and responsive behavior for the homepage.
+`hao-home-center-fix.css` owns the widened native shell, the coordinated title/introduction/profile banner, light content cards, section rhythm, and responsive behavior for the homepage.
 
 Older Mission Log and v6 experiment styles must not be injected or kept as active production CSS.
 
 ## Shell contract
 
-The homepage should follow al-folio's native shell and widen it, rather than replacing it.
+The homepage follows al-folio's native shell and widens it rather than replacing it.
 
 Allowed shell tokens:
 
 - `--hao-alfolio-shell-max`
 - `--hao-alfolio-gutter`
 - `--hao-alfolio-shell`
+- `--hao-home-profile-width`
 
-The following elements should share the same widened shell:
+The production desktop maximum is `84rem`. The following real theme nodes must share the same calculated width and left/right edges:
 
-- `body:has(.hao-home--alfolio) main > .container`
-- `body:has(.hao-home--alfolio) .navbar > .container`
-- `body:has(.hao-home--alfolio) .navbar > .container-fluid`
+- `.hao-home-page > .container[role="main"]`
+- `.hao-home-page #navbar > .container`
+- `.hao-home-page #navbar > .container-fluid`
 
-Within that shell, the visible homepage content should also span the same available width. The `.post`, `article`, `article > .clearfix`, `.hao-home--alfolio`, `.hao-home-intro`, `.hao-home-index`, `.hao-home-section`, and `.hao-home-contact` blocks should not carry narrower outer `max-width` rules. Text paragraphs may keep readable line lengths, but the section and card-grid containers should align with the navbar's left and right edges.
+The al-folio default layout renders the content container directly below `<body>`; it does not render a `main > .container` wrapper. Homepage changes must be based on the generated DOM, not an assumed wrapper.
+
+Within that shell, the `.post`, homepage index, content sections, card grids, and contact block must not carry a narrower outer `max-width`. Individual paragraphs may keep readable line lengths, but section and card-grid containers should align with the navbar shell.
 
 Do not reintroduce competing standalone page-width tokens such as `--hao-page-shell`, old `--hao-home-shell-*`, or `--hao-prod-shell`.
+
+## Banner contract
+
+The native title, subtitle, profile image, and custom introduction form one banner rather than two unrelated vertical blocks.
+
+On desktop:
+
+- `.post` is the banner and page grid.
+- `.post-header` and `.hao-home-intro` occupy the left column.
+- the native `.profile` occupies the right column and spans the title/introduction rows.
+- `.hao-home-index` and all following sections span the full shell below the banner.
+- the upstream `article` and `.clearfix` wrappers may use `display: contents` so their children participate in the banner grid without duplicating the theme layout.
+- the profile must not remain floated.
+
+At tablet and mobile widths, the grid becomes one column. Title and introduction remain the reading lead; the profile follows as a bounded, left-aligned image before the section index.
 
 ## Navbar brand contract
 
@@ -71,8 +91,9 @@ The homepage brand must not be fabricated with `::before` content, hidden with `
 Before a Pages artifact is uploaded, the workflow must verify `_site/index.html` contains:
 
 - `hao-home--alfolio`
+- `hao-home-page`
 - `Research records, shipped tools, and field-informed systems.`
-- `hao-home-center-fix.css?v=20260802-home-width-align`
+- `hao-home-center-fix.css?v=20260803-shell-banner-grid`
 - `hao-home-navbar-brand`
 - `font-weight-bold">Zhihao</span> LIU`
 
@@ -89,9 +110,10 @@ This prevents a green CI run from publishing an artifact that either points to t
 
 The homepage should preserve these rules:
 
-- Keep the native al-folio about-page title, subtitle, profile image, article flow, and clearfix structure visible.
+- Keep the native al-folio about-page title, subtitle, profile image, article, and clearfix semantics.
 - Widen the original al-folio container instead of rebuilding a standalone landing-page shell.
 - Align the visible homepage content blocks to the same left and right shell edges as the navbar.
+- Treat the title, introduction, and profile as one coordinated banner on desktop.
 - Keep the homepage navbar brand visually aligned with al-folio's original brand style: `<span class="font-weight-bold">Zhihao</span> LIU`.
 - Place `Current work`, `Systems`, `Knowledge`, `Trajectory`, and `Contact` as compatible content modules inside the original layout.
 - Use light cards, subtle borders, and the existing purple accent; avoid heavy hero panels, full-bleed canvases, duplicated profile cards, or product-site visual language.
@@ -103,6 +125,6 @@ When the homepage visual layer changes:
 
 1. Update `hao-home-center-fix.css` or the homepage markdown; avoid adding another final CSS layer.
 2. Bump `STYLESHEET_VERSION` in `_plugins/site_visual_polish.rb`.
-3. Keep `test/style_contract.js` aligned with the intended al-folio-compatible shell.
+3. Keep `test/style_contract.js` aligned with the intended al-folio-compatible shell and banner.
 4. Confirm the workflow artifact check passes before merging.
-5. After merge, verify the live page shows the new stylesheet version in its HTML.
+5. After merge, verify the live page shows the new stylesheet version and the `hao-home-page` body class in its HTML.

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -81,7 +81,9 @@ requireIncludes(
   [
     "HOMEPAGE_STYLESHEETS",
     "hao-home-center-fix.css",
-    'STYLESHEET_VERSION = "20260802-home-width-align"',
+    'STYLESHEET_VERSION = "20260803-shell-banner-grid"',
+    "def self.apply_home_body_class(page)",
+    "hao-home-page",
     "def self.apply_home_navbar_brand(page)",
     "navbar-brand title font-weight-lighter hao-home-navbar-brand",
     "<span class=\"font-weight-bold\">Zhihao</span> LIU",
@@ -121,16 +123,18 @@ requireIncludes(
   homeAlfolioCss,
   [
     "al-folio baseline homepage enhancement",
-    "--hao-alfolio-shell-max: 72rem",
-    "Shared al-folio shell: navbar and homepage content use the same edge.",
-    "body:has(.hao-home--alfolio) main > .container",
-    "body:has(.hao-home--alfolio) .navbar > .container",
-    "body:has(.hao-home--alfolio) article > .clearfix",
-    "display: revert !important",
+    "--hao-alfolio-shell-max: 84rem",
+    "One measurable shell for both surfaces.",
+    '.hao-home-page > .container[role="main"]',
+    ".hao-home-page #navbar > .container",
+    ".hao-home-page .post > article > .clearfix",
+    "grid-template-areas:",
+    '"header profile"',
+    "display: contents;",
+    ".hao-home-page .post > article > .profile",
     ".hao-home-navbar-brand",
     ".hao-home--alfolio",
     ".hao-home-intro",
-    ".hao-home-intro .hao-home-eyebrow",
     ".hao-home-section",
     ".hao-home-knowledge-grid",
     "@media (max-width: 992px)",
@@ -143,6 +147,8 @@ requireAbsent(
   [
     'content: "Zhihao LIU"',
     "font-size: 0 !important",
+    "body:has(",
+    "main > .container",
     "--hao-page-shell",
     "--hao-prod-shell",
     ".hao-prod-hero",
@@ -158,8 +164,9 @@ requireIncludes(
   workflow,
   [
     "hao-home--alfolio",
+    "hao-home-page",
     "Research records, shipped tools, and field-informed systems.",
-    "hao-home-center-fix.css?v=20260802-home-width-align",
+    "hao-home-center-fix.css?v=20260803-shell-banner-grid",
     "hao-home-navbar-brand",
     'font-weight-bold">Zhihao</span> LIU',
     "Verify secondary pages keep al-folio baseline",
@@ -216,7 +223,7 @@ for (const hiddenNavPage of ["_pages/projects.md", "_pages/repositories.md", "cv
 }
 
 for (const requiredDoc of ["docs/DESIGN_SYSTEM.md", "docs/REDESIGN_ROADMAP.md", "docs/MISSION_LOG_PLAN.md", "docs/HOMEPAGE_FRONTEND_GOVERNANCE.md"]) {
-  if (!exists(requiredDoc)) failures.push(`Hao redesign documentation missing required path: \`${requiredDoc}\`.`);
+  if (!exists(requiredDoc)) failures.push(`Hao redesign documentation missing required path: \`${requiredPath}\`.`);
 }
 
 if (failures.length > 0) {

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -223,7 +223,7 @@ for (const hiddenNavPage of ["_pages/projects.md", "_pages/repositories.md", "cv
 }
 
 for (const requiredDoc of ["docs/DESIGN_SYSTEM.md", "docs/REDESIGN_ROADMAP.md", "docs/MISSION_LOG_PLAN.md", "docs/HOMEPAGE_FRONTEND_GOVERNANCE.md"]) {
-  if (!exists(requiredDoc)) failures.push(`Hao redesign documentation missing required path: \`${requiredPath}\`.`);
+  if (!exists(requiredDoc)) failures.push(`Hao redesign documentation missing required path: \`${requiredDoc}\`.`);
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## What changed

- targets the actual al-folio content node (`body > .container[role="main"]`) instead of the non-existent `main > .container` wrapper
- introduces an explicit `hao-home-page` body scope so homepage CSS survives PurgeCSS predictably and remains isolated from Blog and other secondary pages
- widens both navigation and homepage content to the same 84rem production shell
- converts the native about-page title, introduction, and profile into one coordinated desktop banner grid
- removes the profile float within the banner; the section index and all later modules span the full shell
- preserves a single-column reading order on tablet and mobile
- bumps the stylesheet cache key and updates CI/style-contract/governance checks

## Expected visual result

- homepage left and right edges align with the navbar
- title/subtitle and introduction occupy the left side of the banner
- profile image and caption occupy the right side without forcing the introduction below the image
- `Current work`, `Systems`, `Knowledge`, `Trajectory`, and `Contact` use the full shared shell below the banner

## Validation

The PR build must pass the existing Jekyll build, stylesheet contract, Ruby syntax, Prettier, generated homepage artifact, and secondary-page isolation checks.