### PR TITLE
Polish homepage hierarchy and shell balance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,9 @@ jobs:
           grep -q 'hao-home--alfolio' _site/index.html
           grep -q 'hao-home-page' _site/index.html
           grep -q 'Research records, shipped tools, and field-informed systems.' _site/index.html
-          grep -q 'hao-home-center-fix.css?v=20260803-shell-banner-grid' _site/index.html
+          grep -q 'I build evidence-driven data systems for climate, energy, and geoscience' _site/index.html
+          grep -q 'Browse current work' _site/index.html
+          grep -q 'hao-home-center-fix.css?v=20260803-ui-polish' _site/index.html
           grep -q 'hao-home-navbar-brand' _site/index.html
           grep -q 'font-weight-bold">Zhihao</span> LIU' _site/index.html
           if grep -q 'mission-log-shell-v2.css' _site/index.html; then

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -11,8 +11,6 @@ profile:
   align: right
   image: blog_pic.jpg
   image_circular: false
-  more_info: >
-    <p>Offshore Bergen · Aug 2020</p>
 
 news: false
 announcements:

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -12,7 +12,7 @@ profile:
   image: blog_pic.jpg
   image_circular: false
   more_info: >
-    <p>📍Offshore Bergen, 2020 Aug</p>
+    <p>Offshore Bergen · Aug 2020</p>
 
 news: false
 announcements:
@@ -36,12 +36,10 @@ home_cta: false
   <section class="hao-home-intro" aria-labelledby="hao-home-intro-title">
     <p class="hao-home-eyebrow">Climate data · Geoscience evidence · AI tools</p>
     <h2 id="hao-home-intro-title">Research records, shipped tools, and field-informed systems.</h2>
-    <p>Hao's Notes is the public surface for my climate data work, geoscience evidence, shipped tools, and local-first systems. It keeps the original al-folio homepage structure, while giving the active work a wider and more organized presentation.</p>
+    <p>I build evidence-driven data systems for climate, energy, and geoscience—from field observations and reproducible research to public tools that support analysis and decisions.</p>
     <div class="hao-home-actions" aria-label="Homepage shortcuts">
-      <a class="hao-home-button hao-home-button--primary" href="#current-work">Current work</a>
-      <a class="hao-home-button" href="#systems">Systems</a>
-      <a class="hao-home-button" href="#knowledge">Knowledge</a>
-      <a class="hao-home-button" href="{{ '/blog/' | relative_url }}">Notes</a>
+      <a class="hao-home-button hao-home-button--primary" href="#current-work">Browse current work</a>
+      <a class="hao-home-button" href="{{ '/blog/' | relative_url }}">Read notes</a>
     </div>
   </section>
 

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -11,7 +11,7 @@ module SiteVisualPolish
   # Bump this value whenever the homepage enhancement layer changes. GitHub
   # Pages and browsers may otherwise keep serving an older CSS response for the
   # same path.
-  STYLESHEET_VERSION = "20260803-shell-banner-grid".freeze
+  STYLESHEET_VERSION = "20260803-ui-polish".freeze
 
   def self.apply_cv_title(page)
     return unless page.relative_path == "cv.md"

--- a/assets/css/hao-home-center-fix.css
+++ b/assets/css/hao-home-center-fix.css
@@ -1,15 +1,23 @@
 /*
  * al-folio baseline homepage enhancement
  *
- * The homepage keeps the upstream about-page DOM, but gives it one explicit
- * production shell and one coordinated banner grid. Secondary pages remain on
- * the native al-folio baseline.
+ * The homepage keeps the upstream about-page DOM, but gives it a wider content
+ * shell, a slightly narrower navigation shell, and one coordinated banner grid.
+ * Secondary pages remain on the native al-folio baseline.
  */
 
 :root {
-  --hao-alfolio-shell-max: 84rem;
+  --hao-alfolio-content-shell-max: 84rem;
+  --hao-alfolio-nav-shell-max: 80rem;
   --hao-alfolio-gutter: clamp(1rem, 3vw, 2.5rem);
-  --hao-alfolio-shell: min(calc(100% - var(--hao-alfolio-gutter) - var(--hao-alfolio-gutter)), var(--hao-alfolio-shell-max));
+  --hao-alfolio-content-shell: min(
+    calc(100% - var(--hao-alfolio-gutter) - var(--hao-alfolio-gutter)),
+    var(--hao-alfolio-content-shell-max)
+  );
+  --hao-alfolio-nav-shell: min(
+    calc(100% - var(--hao-alfolio-gutter) - var(--hao-alfolio-gutter)),
+    var(--hao-alfolio-nav-shell-max)
+  );
   --hao-home-profile-width: clamp(17.5rem, 24vw, 20rem);
   --hao-home-ink: var(--global-text-color, #111827);
   --hao-home-muted: var(--global-text-color-light, #6b7280);
@@ -24,16 +32,24 @@
 }
 
 /*
- * One measurable shell for both surfaces. The theme renders the page container
- * as body > .container[role="main"] and the navigation shell as #navbar >
- * .container; target those real nodes instead of an assumed <main> wrapper.
+ * The homepage content is intentionally a little wider than the navigation.
+ * This keeps the navbar compact while allowing the working grids to use more
+ * horizontal space. The footer follows the navigation shell.
  */
-.hao-home-page > .container[role="main"],
-.hao-home-page #navbar > .container,
-.hao-home-page #navbar > .container-fluid {
+.hao-home-page > .container[role="main"] {
   box-sizing: border-box !important;
-  width: var(--hao-alfolio-shell) !important;
-  max-width: var(--hao-alfolio-shell-max) !important;
+  width: var(--hao-alfolio-content-shell) !important;
+  max-width: var(--hao-alfolio-content-shell-max) !important;
+  margin-right: auto !important;
+  margin-left: auto !important;
+}
+
+.hao-home-page #navbar > .container,
+.hao-home-page #navbar > .container-fluid,
+.hao-home-page footer > .container {
+  box-sizing: border-box !important;
+  width: var(--hao-alfolio-nav-shell) !important;
+  max-width: var(--hao-alfolio-nav-shell-max) !important;
   margin-right: auto !important;
   margin-left: auto !important;
 }
@@ -61,17 +77,16 @@
 }
 
 /*
- * Coordinated banner: native title and custom introduction form one left-hand
- * narrative, while the native profile occupies the right column. display:
- * contents keeps the upstream article/clearfix markup without adding a second
- * landing-page shell.
+ * Coordinated banner: the custom introduction leads on the left. The native
+ * profile image occupies the right column, with the native name and role placed
+ * directly beneath it as the image identity block.
  */
 .hao-home-page .post {
   display: grid;
   grid-template-columns: minmax(0, 1fr) var(--hao-home-profile-width);
   grid-template-areas:
-    "header profile"
     "intro profile"
+    "intro header"
     "index index";
   column-gap: clamp(2rem, 5vw, 5rem);
   align-items: start;
@@ -80,7 +95,25 @@
 .hao-home-page .post > .post-header {
   grid-area: header;
   min-width: 0;
+  margin: 0.9rem 0 0;
+  justify-self: stretch;
+}
+
+.hao-home-page .post > .post-header .post-title {
   margin: 0;
+  color: var(--hao-home-ink);
+  font-size: clamp(1.25rem, 1.8vw, 1.55rem);
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.hao-home-page .post > .post-header .desc {
+  max-width: none;
+  margin: 0.3rem 0 0;
+  color: var(--hao-home-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
 }
 
 .hao-home-page .post > article,
@@ -112,19 +145,7 @@
 }
 
 .hao-home-page .post > article > .profile .more-info {
-  margin-top: 0.75rem;
-  color: var(--hao-home-ink);
-  font-size: 0.9rem;
-  line-height: 1.45;
-}
-
-.hao-home-page .post > article > .profile .more-info p {
-  margin: 0;
-}
-
-.hao-home-page .desc {
-  max-width: 42rem;
-  margin-bottom: 0;
+  display: none;
 }
 
 /* Homepage brand: same semantic class stack as the upstream al-folio header. */
@@ -150,8 +171,8 @@
   grid-area: intro;
   display: block;
   min-width: 0;
-  max-width: 50rem;
-  margin: clamp(1.75rem, 3.2vw, 2.8rem) 0 0;
+  max-width: 51rem;
+  margin: 0;
 }
 
 .hao-home-eyebrow,
@@ -337,9 +358,24 @@
   line-height: 1.35;
 }
 
-.hao-home-card-topline span,
-.hao-home-card-topline strong {
+.hao-home-card-topline span {
   font-weight: 650;
+}
+
+.hao-home-card-topline strong {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.45rem;
+  border: 1px solid color-mix(in srgb, var(--hao-home-accent) 20%, var(--hao-home-line));
+  border-radius: 999px;
+  padding: 0.18rem 0.48rem;
+  background: var(--hao-home-soft);
+  color: var(--hao-home-accent);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+  line-height: 1;
+  text-transform: uppercase;
 }
 
 .hao-home-card h3,
@@ -430,7 +466,8 @@
 
 @media (max-width: 992px) {
   :root {
-    --hao-alfolio-shell-max: 64rem;
+    --hao-alfolio-content-shell-max: 64rem;
+    --hao-alfolio-nav-shell-max: 61rem;
     --hao-alfolio-gutter: clamp(0.9rem, 3.5vw, 1.5rem);
     --hao-home-profile-width: min(22rem, 100%);
   }
@@ -438,21 +475,26 @@
   .hao-home-page .post {
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
+      "profile"
       "header"
       "intro"
-      "profile"
       "index";
   }
 
   .hao-home-page .post > article > .profile {
     width: min(100%, 22rem) !important;
     max-width: 22rem !important;
-    margin-top: 2rem !important;
     justify-self: start;
+  }
+
+  .hao-home-page .post > .post-header {
+    width: min(100%, 22rem);
+    margin-top: 0.85rem;
   }
 
   .hao-home-intro {
     max-width: 46rem;
+    margin-top: 2.4rem;
   }
 
   .hao-home-section,
@@ -464,11 +506,13 @@
 @media (max-width: 760px) {
   .hao-home-page > .container[role="main"],
   .hao-home-page #navbar > .container,
-  .hao-home-page #navbar > .container-fluid {
+  .hao-home-page #navbar > .container-fluid,
+  .hao-home-page footer > .container {
     width: min(calc(100% - 1.25rem), 64rem) !important;
   }
 
-  .hao-home-page .post > article > .profile {
+  .hao-home-page .post > article > .profile,
+  .hao-home-page .post > .post-header {
     width: 100% !important;
   }
 

--- a/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
+++ b/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
@@ -32,47 +32,69 @@ The only homepage-specific visual layer is:
 
 1. `hao-home-center-fix.css`
 
-`hao-home-center-fix.css` owns the widened native shell, the coordinated title/introduction/profile banner, light content cards, section rhythm, and responsive behavior for the homepage.
+`hao-home-center-fix.css` owns the differentiated navigation/content shells, the coordinated introduction/profile/identity banner, light content cards, status labels, section rhythm, and responsive behavior for the homepage.
 
 Older Mission Log and v6 experiment styles must not be injected or kept as active production CSS.
 
 ## Shell contract
 
-The homepage follows al-folio's native shell and widens it rather than replacing it.
+The homepage follows al-folio's native shell and widens it rather than replacing it. The navigation should remain slightly more compact than the working content area: exact equality makes the navbar feel visually stretched, while the homepage grids benefit from additional horizontal space.
 
 Allowed shell tokens:
 
-- `--hao-alfolio-shell-max`
+- `--hao-alfolio-content-shell-max`
+- `--hao-alfolio-nav-shell-max`
 - `--hao-alfolio-gutter`
-- `--hao-alfolio-shell`
+- `--hao-alfolio-content-shell`
+- `--hao-alfolio-nav-shell`
 - `--hao-home-profile-width`
 
-The production desktop maximum is `84rem`. The following real theme nodes must share the same calculated width and left/right edges:
+The production desktop maximums are:
 
-- `.hao-home-page > .container[role="main"]`
-- `.hao-home-page #navbar > .container`
-- `.hao-home-page #navbar > .container-fluid`
+- homepage content: `84rem`
+- navbar and footer: `80rem`
+
+The real theme nodes are assigned as follows:
+
+- `.hao-home-page > .container[role="main"]` uses the content shell.
+- `.hao-home-page #navbar > .container` uses the navigation shell.
+- `.hao-home-page #navbar > .container-fluid` uses the navigation shell.
+- `.hao-home-page footer > .container` uses the navigation shell.
 
 The al-folio default layout renders the content container directly below `<body>`; it does not render a `main > .container` wrapper. Homepage changes must be based on the generated DOM, not an assumed wrapper.
 
-Within that shell, the `.post`, homepage index, content sections, card grids, and contact block must not carry a narrower outer `max-width`. Individual paragraphs may keep readable line lengths, but section and card-grid containers should align with the navbar shell.
+Within the content shell, the `.post`, homepage index, content sections, card grids, and contact block must not carry a narrower outer `max-width`. Individual paragraphs may keep readable line lengths.
 
-Do not reintroduce competing standalone page-width tokens such as `--hao-page-shell`, old `--hao-home-shell-*`, or `--hao-prod-shell`.
+Do not reintroduce competing standalone page-width tokens such as `--hao-alfolio-shell-max`, `--hao-page-shell`, old `--hao-home-shell-*`, or `--hao-prod-shell`.
 
 ## Banner contract
 
-The native title, subtitle, profile image, and custom introduction form one banner rather than two unrelated vertical blocks.
+The custom introduction, native profile image, and native title/subtitle form one coordinated banner.
 
 On desktop:
 
-- `.post` is the banner and page grid.
-- `.post-header` and `.hao-home-intro` occupy the left column.
-- the native `.profile` occupies the right column and spans the title/introduction rows.
-- `.hao-home-index` and all following sections span the full shell below the banner.
+- `.hao-home-intro` occupies the left column and leads the page narrative.
+- the native `.profile` occupies the upper-right column.
+- `.post-header`, containing `Zhihao LIU` and `Climate & Energy Data Scientist`, sits directly beneath the profile image as its identity block.
+- the profile front matter should not add a competing `more_info` caption.
+- `.hao-home-index` and all following sections span the full content shell below the banner.
 - the upstream `article` and `.clearfix` wrappers may use `display: contents` so their children participate in the banner grid without duplicating the theme layout.
 - the profile must not remain floated.
 
-At tablet and mobile widths, the grid becomes one column. Title and introduction remain the reading lead; the profile follows as a bounded, left-aligned image before the section index.
+At tablet and mobile widths, the grid becomes one column in this order:
+
+1. profile image
+2. native name and role
+3. custom introduction
+4. section index
+
+This keeps the identity attached to the image instead of separating it with a long introductory block.
+
+The banner should contain exactly two direct actions: one primary route to current work and one secondary route to notes. The complete section navigation belongs in `.hao-home-index` and should not be duplicated as another row of buttons.
+
+## Card hierarchy contract
+
+Card identifiers remain quiet metadata. Status values use a subtle pill treatment with a light border and the existing theme accent. They should improve scanability without creating a dashboard-like visual system or adding status-specific colors that require a separate taxonomy.
 
 ## Navbar brand contract
 
@@ -93,7 +115,9 @@ Before a Pages artifact is uploaded, the workflow must verify `_site/index.html`
 - `hao-home--alfolio`
 - `hao-home-page`
 - `Research records, shipped tools, and field-informed systems.`
-- `hao-home-center-fix.css?v=20260803-shell-banner-grid`
+- the evidence-driven homepage introduction
+- `Browse current work`
+- `hao-home-center-fix.css?v=20260803-ui-polish`
 - `hao-home-navbar-brand`
 - `font-weight-bold">Zhihao</span> LIU`
 
@@ -111,12 +135,13 @@ This prevents a green CI run from publishing an artifact that either points to t
 The homepage should preserve these rules:
 
 - Keep the native al-folio about-page title, subtitle, profile image, article, and clearfix semantics.
-- Widen the original al-folio container instead of rebuilding a standalone landing-page shell.
-- Align the visible homepage content blocks to the same left and right shell edges as the navbar.
-- Treat the title, introduction, and profile as one coordinated banner on desktop.
+- Widen the original al-folio content container instead of rebuilding a standalone landing-page shell.
+- Keep homepage content slightly wider than the navbar and footer on desktop.
+- Treat the introduction, profile, and identity block as one coordinated banner.
+- Keep `Zhihao LIU` and `Climate & Energy Data Scientist` directly beneath the profile image.
 - Keep the homepage navbar brand visually aligned with al-folio's original brand style: `<span class="font-weight-bold">Zhihao</span> LIU`.
 - Place `Current work`, `Systems`, `Knowledge`, `Trajectory`, and `Contact` as compatible content modules inside the original layout.
-- Use light cards, subtle borders, and the existing purple accent; avoid heavy hero panels, full-bleed canvases, duplicated profile cards, or product-site visual language.
+- Use light cards, subtle borders, restrained status pills, and the existing purple accent; avoid heavy hero panels, full-bleed canvases, duplicated profile cards, or product-site visual language.
 - Keep legacy news, latest posts, selected papers, and announcements disabled unless deliberately reintroduced.
 
 ## Change policy
@@ -125,6 +150,6 @@ When the homepage visual layer changes:
 
 1. Update `hao-home-center-fix.css` or the homepage markdown; avoid adding another final CSS layer.
 2. Bump `STYLESHEET_VERSION` in `_plugins/site_visual_polish.rb`.
-3. Keep `test/style_contract.js` aligned with the intended al-folio-compatible shell and banner.
+3. Keep `test/style_contract.js` aligned with the intended shell, banner, and action hierarchy.
 4. Confirm the workflow artifact check passes before merging.
 5. After merge, verify the live page shows the new stylesheet version and the `hao-home-page` body class in its HTML.

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -81,7 +81,7 @@ requireIncludes(
   [
     "HOMEPAGE_STYLESHEETS",
     "hao-home-center-fix.css",
-    'STYLESHEET_VERSION = "20260803-shell-banner-grid"',
+    'STYLESHEET_VERSION = "20260803-ui-polish"',
     "def self.apply_home_body_class(page)",
     "hao-home-page",
     "def self.apply_home_navbar_brand(page)",
@@ -123,15 +123,20 @@ requireIncludes(
   homeAlfolioCss,
   [
     "al-folio baseline homepage enhancement",
-    "--hao-alfolio-shell-max: 84rem",
-    "One measurable shell for both surfaces.",
+    "--hao-alfolio-content-shell-max: 84rem",
+    "--hao-alfolio-nav-shell-max: 80rem",
+    "The homepage content is intentionally a little wider than the navigation.",
     '.hao-home-page > .container[role="main"]',
     ".hao-home-page #navbar > .container",
+    ".hao-home-page footer > .container",
     ".hao-home-page .post > article > .clearfix",
     "grid-template-areas:",
-    '"header profile"',
+    '"intro profile"',
+    '"intro header"',
+    ".post-header .post-title",
     "display: contents;",
     ".hao-home-page .post > article > .profile",
+    ".hao-home-card-topline strong",
     ".hao-home-navbar-brand",
     ".hao-home--alfolio",
     ".hao-home-intro",
@@ -149,6 +154,7 @@ requireAbsent(
     "font-size: 0 !important",
     "body:has(",
     "main > .container",
+    "--hao-alfolio-shell-max",
     "--hao-page-shell",
     "--hao-prod-shell",
     ".hao-prod-hero",
@@ -166,7 +172,9 @@ requireIncludes(
     "hao-home--alfolio",
     "hao-home-page",
     "Research records, shipped tools, and field-informed systems.",
-    "hao-home-center-fix.css?v=20260803-shell-banner-grid",
+    "I build evidence-driven data systems for climate, energy, and geoscience",
+    "Browse current work",
+    "hao-home-center-fix.css?v=20260803-ui-polish",
     "hao-home-navbar-brand",
     'font-weight-bold">Zhihao</span> LIU',
     "Verify secondary pages keep al-folio baseline",
@@ -182,6 +190,9 @@ requireIncludes(
     "hao-home--production hao-home--alfolio",
     "Climate data · Geoscience evidence · AI tools",
     "Research records, shipped tools, and field-informed systems.",
+    "I build evidence-driven data systems for climate, energy, and geoscience",
+    "Browse current work",
+    "Read notes",
     "Current work",
     "Systems",
     "Knowledge",
@@ -194,6 +205,9 @@ requireIncludes(
 requireAbsent(
   aboutPage,
   [
+    "more_info:",
+    "📍",
+    "It keeps the original al-folio homepage structure",
     "hao-home--safe",
     "hao-home--v6",
     "hao-prod-",
@@ -205,6 +219,10 @@ requireAbsent(
   ],
   "al-folio-compatible homepage",
 );
+const homepageActionCount = (aboutPage.match(/class="hao-home-button/g) || []).length;
+if (homepageActionCount !== 2) {
+  failures.push(`Homepage banner must keep exactly two actions; found ${homepageActionCount}.`);
+}
 requireRegex(aboutPage, /^layout:\s*about\b/m, "Homepage must keep al-folio `layout: about`.");
 requireRegex(aboutPage, /^news:\s*false\b/m, "Hao homepage must keep legacy `news` disabled.");
 requireRegex(aboutPage, /^\s*enabled:\s*false\b/m, "Hao homepage must keep legacy announcements disabled.");


### PR DESCRIPTION
## What changed

- keeps the homepage content shell at 84rem while narrowing the navbar and footer shell to 80rem, so the working content reads slightly wider than the navigation
- moves the native `Zhihao LIU` and `Climate & Energy Data Scientist` identity block directly beneath the profile image
- removes the competing photo caption and keeps the image/name/role as one visual unit
- replaces implementation-facing homepage copy with a visitor-facing description of the climate, energy, and geoscience work
- reduces the banner shortcuts to two actions and leaves complete navigation to the section index
- adds restrained status pills for better card scanning
- reorders tablet/mobile content as image → name/role → introduction → section index
- aligns the footer with the narrower navigation shell
- bumps the stylesheet cache key and updates CI, style contracts, and governance documentation

## Expected visual result

- homepage grids extend slightly beyond the navbar on desktop without feeling disconnected
- the profile image and identity read as one coherent right-hand block
- the first screen has one clear narrative and avoids duplicated navigation
- mobile identity remains attached to the image

## Validation

The PR build must pass the style contract, Prettier, Ruby syntax, production Jekyll build, generated homepage checks, PurgeCSS, and secondary-page isolation checks.