### PR TITLE
Align homepage shell and restore profile contact details

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,8 +82,9 @@ jobs:
           grep -q 'hao-home-page' _site/index.html
           grep -q 'Research records, shipped tools, and field-informed systems.' _site/index.html
           grep -q 'I build evidence-driven data systems for climate, energy, and geoscience' _site/index.html
-          grep -q 'Browse current work' _site/index.html
-          grep -q 'hao-home-center-fix.css?v=20260803-ui-polish' _site/index.html
+          grep -q 'Offshore Bergen · Aug 2020' _site/index.html
+          grep -q 'calendar.app.google/UQ267iEs4MTAGFSd7' _site/index.html
+          grep -q 'hao-home-center-fix.css?v=20260803-shell-contact-caption' _site/index.html
           grep -q 'hao-home-navbar-brand' _site/index.html
           grep -q 'font-weight-bold">Zhihao</span> LIU' _site/index.html
           if grep -q 'mission-log-shell-v2.css' _site/index.html; then

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -11,6 +11,8 @@ profile:
   align: right
   image: blog_pic.jpg
   image_circular: false
+  more_info: >
+    <p>Offshore Bergen · Aug 2020</p>
 
 news: false
 announcements:
@@ -35,9 +37,8 @@ home_cta: false
     <p class="hao-home-eyebrow">Climate data · Geoscience evidence · AI tools</p>
     <h2 id="hao-home-intro-title">Research records, shipped tools, and field-informed systems.</h2>
     <p>I build evidence-driven data systems for climate, energy, and geoscience—from field observations and reproducible research to public tools that support analysis and decisions.</p>
-    <div class="hao-home-actions" aria-label="Homepage shortcuts">
-      <a class="hao-home-button hao-home-button--primary" href="#current-work">Browse current work</a>
-      <a class="hao-home-button" href="{{ '/blog/' | relative_url }}">Read notes</a>
+    <div class="hao-home-actions" aria-label="Homepage contact">
+      <a class="hao-home-button hao-home-button--primary" href="https://calendar.app.google/UQ267iEs4MTAGFSd7" target="_blank" rel="noopener noreferrer" aria-label="Contact — book a chat">Contact</a>
     </div>
   </section>
 

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -11,7 +11,7 @@ module SiteVisualPolish
   # Bump this value whenever the homepage enhancement layer changes. GitHub
   # Pages and browsers may otherwise keep serving an older CSS response for the
   # same path.
-  STYLESHEET_VERSION = "20260803-ui-polish".freeze
+  STYLESHEET_VERSION = "20260803-shell-contact-caption".freeze
 
   def self.apply_cv_title(page)
     return unless page.relative_path == "cv.md"

--- a/assets/css/hao-home-center-fix.css
+++ b/assets/css/hao-home-center-fix.css
@@ -1,14 +1,14 @@
 /*
  * al-folio baseline homepage enhancement
  *
- * The homepage keeps the upstream about-page DOM, but gives it a wider content
- * shell, a slightly narrower navigation shell, and one coordinated banner grid.
+ * The homepage keeps the upstream about-page DOM, gives navigation, content,
+ * and footer one shared visual shell, and coordinates the banner grid.
  * Secondary pages remain on the native al-folio baseline.
  */
 
 :root {
   --hao-alfolio-content-shell-max: 84rem;
-  --hao-alfolio-nav-shell-max: 80rem;
+  --hao-alfolio-nav-shell-max: 84rem;
   --hao-alfolio-gutter: clamp(1rem, 3vw, 2.5rem);
   --hao-alfolio-content-shell: min(
     calc(100% - var(--hao-alfolio-gutter) - var(--hao-alfolio-gutter)),
@@ -31,11 +31,7 @@
   overflow-x: clip;
 }
 
-/*
- * The homepage content is intentionally a little wider than the navigation.
- * This keeps the navbar compact while allowing the working grids to use more
- * horizontal space. The footer follows the navigation shell.
- */
+/* Navigation, homepage content, and footer share the same measured edges. */
 .hao-home-page > .container[role="main"] {
   box-sizing: border-box !important;
   width: var(--hao-alfolio-content-shell) !important;
@@ -78,8 +74,8 @@
 
 /*
  * Coordinated banner: the custom introduction leads on the left. The native
- * profile image occupies the right column, with the native name and role placed
- * directly beneath it as the image identity block.
+ * profile image occupies the right column, with its field caption and native
+ * name/role directly beneath it as one identity block.
  */
 .hao-home-page .post {
   display: grid;
@@ -145,7 +141,15 @@
 }
 
 .hao-home-page .post > article > .profile .more-info {
-  display: none;
+  display: block;
+  margin: 0.55rem 0 0;
+  color: var(--hao-home-muted);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.hao-home-page .post > article > .profile .more-info p {
+  margin: 0;
 }
 
 /* Homepage brand: same semantic class stack as the upstream al-folio header. */
@@ -467,7 +471,7 @@
 @media (max-width: 992px) {
   :root {
     --hao-alfolio-content-shell-max: 64rem;
-    --hao-alfolio-nav-shell-max: 61rem;
+    --hao-alfolio-nav-shell-max: 64rem;
     --hao-alfolio-gutter: clamp(0.9rem, 3.5vw, 1.5rem);
     --hao-home-profile-width: min(22rem, 100%);
   }

--- a/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
+++ b/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
@@ -32,13 +32,13 @@ The only homepage-specific visual layer is:
 
 1. `hao-home-center-fix.css`
 
-`hao-home-center-fix.css` owns the differentiated navigation/content shells, the coordinated introduction/profile/identity banner, light content cards, status labels, section rhythm, and responsive behavior for the homepage.
+`hao-home-center-fix.css` owns the shared navigation/content/footer shell, the coordinated introduction/profile/identity banner, light content cards, status labels, section rhythm, and responsive behavior for the homepage.
 
 Older Mission Log and v6 experiment styles must not be injected or kept as active production CSS.
 
 ## Shell contract
 
-The homepage follows al-folio's native shell and widens it rather than replacing it. The navigation should remain slightly more compact than the working content area: exact equality makes the navbar feel visually stretched, while the homepage grids benefit from additional horizontal space.
+The homepage follows al-folio's native shell and widens it rather than replacing it. Navigation, homepage content, and footer must use the same measured left and right edges. A visually wider content shell than the navigation is not allowed because it creates a subtle but noticeable alignment break across the page.
 
 Allowed shell tokens:
 
@@ -49,10 +49,10 @@ Allowed shell tokens:
 - `--hao-alfolio-nav-shell`
 - `--hao-home-profile-width`
 
-The production desktop maximums are:
+The production desktop maximum is `84rem` for both shell calculations:
 
 - homepage content: `84rem`
-- navbar and footer: `80rem`
+- navbar and footer: `84rem`
 
 The real theme nodes are assigned as follows:
 
@@ -61,36 +61,38 @@ The real theme nodes are assigned as follows:
 - `.hao-home-page #navbar > .container-fluid` uses the navigation shell.
 - `.hao-home-page footer > .container` uses the navigation shell.
 
+Although the code retains separate semantic content and navigation variables, their maximum width and gutter calculation must remain identical. This preserves explicit ownership while guaranteeing visual alignment.
+
 The al-folio default layout renders the content container directly below `<body>`; it does not render a `main > .container` wrapper. Homepage changes must be based on the generated DOM, not an assumed wrapper.
 
-Within the content shell, the `.post`, homepage index, content sections, card grids, and contact block must not carry a narrower outer `max-width`. Individual paragraphs may keep readable line lengths.
+Within the shared shell, the `.post`, homepage index, content sections, card grids, and contact block must not carry a narrower outer `max-width`. Individual paragraphs may keep readable line lengths.
 
 Do not reintroduce competing standalone page-width tokens such as `--hao-alfolio-shell-max`, `--hao-page-shell`, old `--hao-home-shell-*`, or `--hao-prod-shell`.
 
 ## Banner contract
 
-The custom introduction, native profile image, and native title/subtitle form one coordinated banner.
+The custom introduction, native profile image, profile caption, and native title/subtitle form one coordinated banner.
 
 On desktop:
 
 - `.hao-home-intro` occupies the left column and leads the page narrative.
 - the native `.profile` occupies the upper-right column.
-- `.post-header`, containing `Zhihao LIU` and `Climate & Energy Data Scientist`, sits directly beneath the profile image as its identity block.
-- the profile front matter should not add a competing `more_info` caption.
-- `.hao-home-index` and all following sections span the full content shell below the banner.
+- the profile caption `Offshore Bergen · Aug 2020` remains directly beneath the image as quiet field metadata.
+- `.post-header`, containing `Zhihao LIU` and `Climate & Energy Data Scientist`, sits beneath the image and caption as the identity block.
+- `.hao-home-index` and all following sections span the full shared shell below the banner.
 - the upstream `article` and `.clearfix` wrappers may use `display: contents` so their children participate in the banner grid without duplicating the theme layout.
 - the profile must not remain floated.
 
 At tablet and mobile widths, the grid becomes one column in this order:
 
-1. profile image
+1. profile image and field caption
 2. native name and role
 3. custom introduction
 4. section index
 
-This keeps the identity attached to the image instead of separating it with a long introductory block.
+This keeps the complete identity unit together instead of separating the image, caption, and name with a long introductory block.
 
-The banner should contain exactly two direct actions: one primary route to current work and one secondary route to notes. The complete section navigation belongs in `.hao-home-index` and should not be duplicated as another row of buttons.
+The banner contains exactly one direct action: `Contact`. It links to the existing Google appointment page at `https://calendar.app.google/UQ267iEs4MTAGFSd7`. The complete internal section navigation belongs in `.hao-home-index`; it should not be duplicated as another button row in the banner.
 
 ## Card hierarchy contract
 
@@ -116,8 +118,9 @@ Before a Pages artifact is uploaded, the workflow must verify `_site/index.html`
 - `hao-home-page`
 - `Research records, shipped tools, and field-informed systems.`
 - the evidence-driven homepage introduction
-- `Browse current work`
-- `hao-home-center-fix.css?v=20260803-ui-polish`
+- `Offshore Bergen · Aug 2020`
+- the Google appointment URL
+- `hao-home-center-fix.css?v=20260803-shell-contact-caption`
 - `hao-home-navbar-brand`
 - `font-weight-bold">Zhihao</span> LIU`
 
@@ -135,10 +138,11 @@ This prevents a green CI run from publishing an artifact that either points to t
 The homepage should preserve these rules:
 
 - Keep the native al-folio about-page title, subtitle, profile image, article, and clearfix semantics.
-- Widen the original al-folio content container instead of rebuilding a standalone landing-page shell.
-- Keep homepage content slightly wider than the navbar and footer on desktop.
-- Treat the introduction, profile, and identity block as one coordinated banner.
-- Keep `Zhihao LIU` and `Climate & Energy Data Scientist` directly beneath the profile image.
+- Widen the original al-folio container instead of rebuilding a standalone landing-page shell.
+- Keep navigation, homepage content, and footer visually aligned to the same left and right edges.
+- Treat the introduction, profile, field caption, and identity block as one coordinated banner.
+- Keep `Offshore Bergen · Aug 2020`, `Zhihao LIU`, and `Climate & Energy Data Scientist` grouped beneath the profile image.
+- Use one banner action, `Contact`, linked to the Google booking page; keep internal navigation in the section index.
 - Keep the homepage navbar brand visually aligned with al-folio's original brand style: `<span class="font-weight-bold">Zhihao</span> LIU`.
 - Place `Current work`, `Systems`, `Knowledge`, `Trajectory`, and `Contact` as compatible content modules inside the original layout.
 - Use light cards, subtle borders, restrained status pills, and the existing purple accent; avoid heavy hero panels, full-bleed canvases, duplicated profile cards, or product-site visual language.
@@ -150,6 +154,6 @@ When the homepage visual layer changes:
 
 1. Update `hao-home-center-fix.css` or the homepage markdown; avoid adding another final CSS layer.
 2. Bump `STYLESHEET_VERSION` in `_plugins/site_visual_polish.rb`.
-3. Keep `test/style_contract.js` aligned with the intended shell, banner, and action hierarchy.
+3. Keep `test/style_contract.js` aligned with the intended shell, banner, caption, and action hierarchy.
 4. Confirm the workflow artifact check passes before merging.
 5. After merge, verify the live page shows the new stylesheet version and the `hao-home-page` body class in its HTML.

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -81,7 +81,7 @@ requireIncludes(
   [
     "HOMEPAGE_STYLESHEETS",
     "hao-home-center-fix.css",
-    'STYLESHEET_VERSION = "20260803-ui-polish"',
+    'STYLESHEET_VERSION = "20260803-shell-contact-caption"',
     "def self.apply_home_body_class(page)",
     "hao-home-page",
     "def self.apply_home_navbar_brand(page)",
@@ -124,8 +124,8 @@ requireIncludes(
   [
     "al-folio baseline homepage enhancement",
     "--hao-alfolio-content-shell-max: 84rem",
-    "--hao-alfolio-nav-shell-max: 80rem",
-    "The homepage content is intentionally a little wider than the navigation.",
+    "--hao-alfolio-nav-shell-max: 84rem",
+    "Navigation, homepage content, and footer share the same measured edges.",
     '.hao-home-page > .container[role="main"]',
     ".hao-home-page #navbar > .container",
     ".hao-home-page footer > .container",
@@ -136,6 +136,7 @@ requireIncludes(
     ".post-header .post-title",
     "display: contents;",
     ".hao-home-page .post > article > .profile",
+    ".profile .more-info",
     ".hao-home-card-topline strong",
     ".hao-home-navbar-brand",
     ".hao-home--alfolio",
@@ -173,8 +174,9 @@ requireIncludes(
     "hao-home-page",
     "Research records, shipped tools, and field-informed systems.",
     "I build evidence-driven data systems for climate, energy, and geoscience",
-    "Browse current work",
-    "hao-home-center-fix.css?v=20260803-ui-polish",
+    "Offshore Bergen · Aug 2020",
+    "calendar.app.google/UQ267iEs4MTAGFSd7",
+    "hao-home-center-fix.css?v=20260803-shell-contact-caption",
     "hao-home-navbar-brand",
     'font-weight-bold">Zhihao</span> LIU',
     "Verify secondary pages keep al-folio baseline",
@@ -191,13 +193,15 @@ requireIncludes(
     "Climate data · Geoscience evidence · AI tools",
     "Research records, shipped tools, and field-informed systems.",
     "I build evidence-driven data systems for climate, energy, and geoscience",
-    "Browse current work",
-    "Read notes",
+    "more_info:",
+    "Offshore Bergen · Aug 2020",
+    "calendar.app.google/UQ267iEs4MTAGFSd7",
+    "aria-label=\"Contact — book a chat\"",
+    ">Contact</a>",
     "Current work",
     "Systems",
     "Knowledge",
     "Trajectory",
-    "Contact",
     "hao-home-contact",
   ],
   "al-folio-compatible homepage",
@@ -205,8 +209,9 @@ requireIncludes(
 requireAbsent(
   aboutPage,
   [
-    "more_info:",
     "📍",
+    "Browse current work",
+    "Read notes",
     "It keeps the original al-folio homepage structure",
     "hao-home--safe",
     "hao-home--v6",
@@ -220,8 +225,8 @@ requireAbsent(
   "al-folio-compatible homepage",
 );
 const homepageActionCount = (aboutPage.match(/class="hao-home-button/g) || []).length;
-if (homepageActionCount !== 2) {
-  failures.push(`Homepage banner must keep exactly two actions; found ${homepageActionCount}.`);
+if (homepageActionCount !== 1) {
+  failures.push(`Homepage banner must keep exactly one contact action; found ${homepageActionCount}.`);
 }
 requireRegex(aboutPage, /^layout:\s*about\b/m, "Homepage must keep al-folio `layout: about`.");
 requireRegex(aboutPage, /^news:\s*false\b/m, "Hao homepage must keep legacy `news` disabled.");


### PR DESCRIPTION
## What changed

- restores one visual width for navigation, homepage content, and footer at 84rem
- restores `Offshore Bergen · Aug 2020` beneath the profile image
- keeps `Zhihao LIU` and `Climate & Energy Data Scientist` grouped beneath the image and caption
- replaces the banner shortcut row with one `Contact` action linked to the existing Google booking page
- keeps internal page navigation in the section index instead of duplicating it as banner buttons
- updates the stylesheet cache key, CI artifact checks, style contract, and homepage governance

## Expected visual result

- navbar, content sections, and footer share the same left and right edges
- the profile image, field caption, name, and role read as one coherent identity block
- the banner has one clear external contact action while section navigation remains below

## Validation

The PR build must pass the style contract, Prettier, Ruby syntax, production Jekyll build, homepage artifact checks, PurgeCSS, and secondary-page isolation checks.