### PR TITLE
Hide the CV TOC scrollbar and narrow the homepage shell

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
           grep -q 'NuthKaab Coreg vs Gradient Descent Coreg' _site/index.html
           grep -q 'Quad 35 hybrid seismic acquisition' _site/index.html
           grep -q 'calendar.app.google/UQ267iEs4MTAGFSd7' _site/index.html
-          grep -q 'hao-home-center-fix.css?v=20260803-content-audit-optical-shell' _site/index.html
+          grep -q 'hao-home-center-fix.css?v=20260803-cv-toc-home-81' _site/index.html
           grep -q 'hao-home-navbar-brand' _site/index.html
           grep -q 'font-weight-bold">Zhihao</span> LIU' _site/index.html
           if grep -q 'id="trajectory"' _site/index.html; then
@@ -96,12 +96,23 @@ jobs:
             exit 1
           fi
 
+      - name: Verify CV TOC polish artifact 🔎
+        run: |
+          set -euo pipefail
+          test -f _site/cv/index.html
+          grep -q 'hao-cv-page' _site/cv/index.html
+          grep -q 'id="toc-sidebar"' _site/cv/index.html
+          grep -q 'cv-toc-polish.css?v=20260803-cv-toc-home-81' _site/cv/index.html
+          test -f _site/assets/css/cv-toc-polish.css
+          grep -q 'scrollbar-width: none' _site/assets/css/cv-toc-polish.css
+          grep -q '::-webkit-scrollbar' _site/assets/css/cv-toc-polish.css
+
       - name: Verify secondary pages keep al-folio baseline 🔎
         run: |
           set -euo pipefail
           test -f _site/blog/index.html
-          if grep -Eq 'site-polish.css|site-upgrade.css|hao-design.css|hao-home-safe.css|hao-home-center-fix.css' _site/blog/index.html; then
-            echo "Custom visual stylesheet leaked into blog index; secondary pages should keep the al-folio baseline."
+          if grep -Eq 'site-polish.css|site-upgrade.css|hao-design.css|hao-home-safe.css|hao-home-center-fix.css|cv-toc-polish.css' _site/blog/index.html; then
+            echo "Scoped visual stylesheet leaked into blog index; secondary pages should keep the al-folio baseline."
             exit 1
           fi
 

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -1,20 +1,26 @@
 # frozen_string_literal: true
 
 module SiteVisualPolish
-  # Keep the starter close to upstream al-folio by default. Secondary pages such
-  # as Blog, Projects, Repositories, and CV should use the theme's native visual
-  # grammar unless a change is deliberately made in the theme/gem layer.
+  # Keep the starter close to upstream al-folio by default. The homepage owns one
+  # scoped layout stylesheet; the CV owns one narrowly scoped TOC polish layer.
   HOMEPAGE_STYLESHEETS = [
     "hao-home-center-fix.css"
   ].freeze
 
-  # Bump this value whenever the homepage enhancement layer changes. GitHub
-  # Pages and browsers may otherwise keep serving an older CSS response for the
-  # same path.
-  STYLESHEET_VERSION = "20260803-content-audit-optical-shell".freeze
+  CV_STYLESHEETS = [
+    "cv-toc-polish.css"
+  ].freeze
+
+  # Bump this value whenever either scoped visual layer changes. GitHub Pages and
+  # browsers may otherwise keep serving an older CSS response for the same path.
+  STYLESHEET_VERSION = "20260803-cv-toc-home-81".freeze
+
+  def self.cv_page?(page)
+    page.relative_path == "cv.md" || page.url.to_s == "/cv/"
+  end
 
   def self.apply_cv_title(page)
-    return unless page.relative_path == "cv.md"
+    return unless cv_page?(page)
 
     page.output = page.output.sub(
       %r{(<a class="anchor" id="publications"></a>\s*<div class="card mt-3 p-3">\s*<h3 class="card-title font-weight-medium">)Publications(</h3>)},
@@ -34,6 +40,13 @@ module SiteVisualPolish
     page.output = page.output.sub('<body class="', '<body class="hao-home-page ')
   end
 
+  def self.apply_cv_body_class(page)
+    return unless cv_page?(page)
+    return if page.output.include?("hao-cv-page")
+
+    page.output = page.output.sub('<body class="', '<body class="hao-cv-page ')
+  end
+
   def self.apply_home_navbar_brand(page)
     return unless home_page?(page)
     return unless page.output.include?("hao-home--alfolio")
@@ -48,13 +61,12 @@ module SiteVisualPolish
     page.output = page.output.sub(navbar_container, "\\1\n      #{brand}")
   end
 
-  def self.apply_homepage_stylesheet(page)
-    return unless home_page?(page)
+  def self.apply_stylesheets(page, stylesheets)
     return unless page.output.include?("</head>")
 
     baseurl = page.site.config["baseurl"].to_s.sub(%r{/$}, "")
 
-    HOMEPAGE_STYLESHEETS.each do |stylesheet|
+    stylesheets.each do |stylesheet|
       next if page.output.include?(stylesheet)
 
       href = "#{baseurl}/assets/css/#{stylesheet}?v=#{STYLESHEET_VERSION}"
@@ -62,13 +74,27 @@ module SiteVisualPolish
       page.output = page.output.sub("</head>", "#{tag}</head>")
     end
   end
+
+  def self.apply_homepage_stylesheet(page)
+    return unless home_page?(page)
+
+    apply_stylesheets(page, HOMEPAGE_STYLESHEETS)
+  end
+
+  def self.apply_cv_stylesheet(page)
+    return unless cv_page?(page)
+
+    apply_stylesheets(page, CV_STYLESHEETS)
+  end
 end
 
 [:pages, :documents].each do |hook_owner|
   Jekyll::Hooks.register hook_owner, :post_render do |page|
     SiteVisualPolish.apply_cv_title(page)
     SiteVisualPolish.apply_home_body_class(page)
+    SiteVisualPolish.apply_cv_body_class(page)
     SiteVisualPolish.apply_home_navbar_brand(page)
     SiteVisualPolish.apply_homepage_stylesheet(page)
+    SiteVisualPolish.apply_cv_stylesheet(page)
   end
 end

--- a/assets/css/cv-toc-polish.css
+++ b/assets/css/cv-toc-polish.css
@@ -1,0 +1,24 @@
+/*
+ * CV table-of-contents polish
+ *
+ * Tocbot keeps the left navigation vertically scrollable on long CV pages. Hide
+ * the native scrollbar chrome without disabling wheel, touch, or keyboard
+ * scrolling.
+ */
+
+.hao-cv-page #toc-sidebar,
+.hao-cv-page #toc-sidebar .toc-list {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.hao-cv-page #toc-sidebar::-webkit-scrollbar,
+.hao-cv-page #toc-sidebar .toc-list::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.hao-cv-page #toc-sidebar {
+  overscroll-behavior: contain;
+}

--- a/assets/css/hao-home-center-fix.css
+++ b/assets/css/hao-home-center-fix.css
@@ -7,7 +7,7 @@
  */
 
 :root {
-  --hao-alfolio-content-shell-max: 82rem;
+  --hao-alfolio-content-shell-max: 81rem;
   --hao-alfolio-nav-shell-max: 84rem;
   --hao-alfolio-gutter: clamp(1rem, 3vw, 2.5rem);
   --hao-alfolio-content-shell: min(
@@ -33,7 +33,7 @@
 
 /*
  * Optical alignment: the navbar container keeps its native 15px inline padding.
- * A content shell two rem narrower places the homepage's visible edges on the
+ * A content shell three rem narrower places the homepage's visible edges on the
  * same lines as the navbar brand and menu, rather than its outer box.
  */
 .hao-home-page > .container[role="main"] {

--- a/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
+++ b/docs/HOMEPAGE_FRONTEND_GOVERNANCE.md
@@ -4,7 +4,7 @@ This document records the production rules for the Hao's Notes homepage after th
 
 ## Ownership model
 
-The site keeps upstream al-folio as its visual baseline. Blog, Projects, Repositories, CV, publications, and individual posts must not receive broad custom visual CSS from this starter repository.
+The site keeps upstream al-folio as its visual baseline. Blog, Projects, Repositories, publications, and individual posts must not receive broad custom visual CSS from this starter repository.
 
 The homepage keeps the native `layout: about` DOM and adds one scoped content root:
 
@@ -14,17 +14,19 @@ The homepage keeps the native `layout: about` DOM and adds one scoped content ro
 
 `_plugins/site_visual_polish.rb` adds `hao-home-page` to the rendered `<body>` and injects only `hao-home-center-fix.css` on `/`.
 
+The CV is the only secondary-page exception. It receives `hao-cv-page` and the narrowly scoped `cv-toc-polish.css` layer, which hides the native TOC scrollbar chrome while preserving the existing tocbot scrolling behavior.
+
 ## Optical shell contract
 
 The theme's `.container` includes 15 px of inline padding. Matching the outer boxes of the navbar and main container therefore did not match their visible content edges.
 
 The desktop shell uses:
 
-- homepage content outer width: `82rem`
+- homepage content outer width: `81rem`
 - navbar and footer outer width: `84rem`
 - shared gutter calculation: `clamp(1rem, 3vw, 2.5rem)`
 
-This two-rem difference is deliberate optical compensation. The visible left edge of the homepage should align with the navbar brand, and the visible right edge should align with the navbar controls. Do not describe the two outer containers as numerically identical.
+This three-rem difference is deliberate optical compensation. The visible left edge of the homepage should align with the navbar brand, and the visible right edge should align with the navbar controls. Do not describe the two outer containers as numerically identical.
 
 The scoped nodes are:
 
@@ -84,6 +86,17 @@ The Projects & code section draws from real archive entries such as:
 
 The Notes & publications section includes the 2025 snow-depth paper, the underwater seismic-device patent, and selected published notes.
 
+## CV TOC contract
+
+The CV keeps the upstream left-side `#toc-sidebar` and its sticky, vertically scrollable behavior. The custom layer must only remove scrollbar chrome:
+
+- use `scrollbar-width: none` for Firefox;
+- use `-ms-overflow-style: none` for legacy Microsoft engines;
+- hide `::-webkit-scrollbar` for Chromium and Safari;
+- do not set `overflow-y: hidden` or disable wheel, touch, or keyboard scrolling.
+
+The stylesheet must load only on `/cv/` and must not leak into Blog or other secondary pages.
+
 ## Navbar brand contract
 
 The homepage navbar brand is injected as real markup:
@@ -107,17 +120,19 @@ Before upload, CI must verify that `_site/index.html` contains:
 - `Notes &amp; publications`
 - representative real archive items
 - the Google booking URL
-- `hao-home-center-fix.css?v=20260803-content-audit-optical-shell`
+- `hao-home-center-fix.css?v=20260803-cv-toc-home-81`
 - the navbar brand
 
-CI must reject a homepage that still contains `id="trajectory"`. Secondary pages must not load the homepage stylesheet.
+CI must also verify that `_site/cv/index.html` contains `hao-cv-page`, `#toc-sidebar`, and `cv-toc-polish.css?v=20260803-cv-toc-home-81`.
+
+CI must reject a homepage that still contains `id="trajectory"`. Blog and other secondary pages must not load either scoped stylesheet.
 
 ## Change policy
 
-When the homepage changes:
+When the homepage or CV TOC polish changes:
 
-1. update the existing homepage markdown, data files, or `hao-home-center-fix.css`;
-2. do not add another final CSS layer;
+1. update the existing homepage markdown, data files, `hao-home-center-fix.css`, or `cv-toc-polish.css`;
+2. do not add another final CSS layer for the same surface;
 3. bump `STYLESHEET_VERSION`;
 4. update the style contract and built-artifact checks;
 5. merge only after the production Jekyll build and secondary-page isolation checks pass.

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -81,13 +81,20 @@ requireIncludes(
   [
     "HOMEPAGE_STYLESHEETS",
     "hao-home-center-fix.css",
-    'STYLESHEET_VERSION = "20260803-content-audit-optical-shell"',
+    "CV_STYLESHEETS",
+    "cv-toc-polish.css",
+    'STYLESHEET_VERSION = "20260803-cv-toc-home-81"',
+    "def self.cv_page?(page)",
     "def self.apply_home_body_class(page)",
     "hao-home-page",
+    "def self.apply_cv_body_class(page)",
+    "hao-cv-page",
     "def self.apply_home_navbar_brand(page)",
     "navbar-brand title font-weight-lighter hao-home-navbar-brand",
     '<span class="font-weight-bold">Zhihao</span> LIU',
+    "def self.apply_stylesheets(page, stylesheets)",
     "def self.apply_homepage_stylesheet(page)",
+    "def self.apply_cv_stylesheet(page)",
     "?v=#{STYLESHEET_VERSION}",
   ],
   "Site visual polish plugin",
@@ -118,9 +125,10 @@ requireIncludes(
   homeCss,
   [
     "al-folio baseline homepage enhancement",
-    "--hao-alfolio-content-shell-max: 82rem",
+    "--hao-alfolio-content-shell-max: 81rem",
     "--hao-alfolio-nav-shell-max: 84rem",
     "Optical alignment: the navbar container keeps its native 15px inline padding.",
+    "A content shell three rem narrower",
     '.hao-home-page > .container[role="main"]',
     ".hao-home-page #navbar > .container",
     ".hao-home-page footer > .container",
@@ -156,6 +164,25 @@ requireAbsent(
   ],
   "Homepage CSS",
 );
+
+if (!exists("assets/css/cv-toc-polish.css")) {
+  failures.push("CV TOC polish CSS missing: `assets/css/cv-toc-polish.css`.");
+}
+
+const cvTocCss = exists("assets/css/cv-toc-polish.css") ? read("assets/css/cv-toc-polish.css") : "";
+requireIncludes(
+  cvTocCss,
+  [
+    "CV table-of-contents polish",
+    ".hao-cv-page #toc-sidebar",
+    "scrollbar-width: none",
+    "-ms-overflow-style: none",
+    "::-webkit-scrollbar",
+    "overscroll-behavior: contain",
+  ],
+  "CV TOC CSS",
+);
+requireAbsent(cvTocCss, ["overflow-y: hidden", "display: none !important"], "CV TOC CSS");
 
 const aboutPage = read("_pages/about.md");
 requireIncludes(
@@ -202,6 +229,9 @@ if (homepageActionCount !== 1) {
 
 requireRegex(aboutPage, /^layout:\s*about\b/m, "Homepage must keep al-folio `layout: about`.");
 requireRegex(aboutPage, /^news:\s*false\b/m, "Hao homepage must keep legacy `news` disabled.");
+
+const cvPage = read("cv.md");
+requireIncludes(cvPage, ["layout: cv", "sidebar: left"], "CV page");
 
 const selectedWork = read("_data/selected_deployments.yml");
 requireIncludes(
@@ -253,9 +283,13 @@ requireIncludes(
     "Notes &amp; publications",
     "NuthKaab Coreg vs Gradient Descent Coreg",
     "Quad 35 hybrid seismic acquisition",
-    "hao-home-center-fix.css?v=20260803-content-audit-optical-shell",
+    "hao-home-center-fix.css?v=20260803-cv-toc-home-81",
     "hao-home-navbar-brand",
     'font-weight-bold">Zhihao</span> LIU',
+    "Verify CV TOC polish artifact",
+    "hao-cv-page",
+    "cv-toc-polish.css?v=20260803-cv-toc-home-81",
+    "scrollbar-width: none",
     "Verify secondary pages keep al-folio baseline",
   ],
   "Deploy workflow",


### PR DESCRIPTION
## What changed

- narrows the homepage content shell from 82rem to 81rem while keeping the navbar/footer shell at 84rem for a slightly tighter optical alignment
- adds a CV-only body scope and stylesheet
- hides the native scrollbar chrome on the left CV table of contents while preserving wheel, touch, and keyboard scrolling
- keeps the CV TOC sticky and vertically scrollable
- updates the stylesheet cache key, CI artifact checks, style contract, and frontend governance

## Validation

The PR build must pass the style contract, Prettier, Ruby syntax, production Jekyll build, homepage artifact checks, CV artifact checks, PurgeCSS, and secondary-page isolation checks.