### PR TITLE
feat: add atmospheric depth to homepage visual system

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -4,7 +4,8 @@ module SiteVisualPolish
   # Keep the starter close to upstream al-folio by default. The homepage owns one
   # scoped layout stylesheet; CV and Repositories own narrow component layers.
   HOMEPAGE_STYLESHEETS = [
-    "hao-home-center-fix.css"
+    "hao-home-center-fix.css",
+    "hao-home-atmosphere.css"
   ].freeze
 
   CV_STYLESHEETS = [
@@ -15,8 +16,6 @@ module SiteVisualPolish
     "repositories-page-polish.css"
   ].freeze
 
-  # The homepage and CV files are unchanged in this round. The repositories
-  # stylesheet has a new path, so it does not inherit an older cached response.
   STYLESHEET_VERSION = "20260803-cv-toc-home-81".freeze
 
   def self.cv_page?(page)

--- a/assets/css/hao-home-atmosphere.css
+++ b/assets/css/hao-home-atmosphere.css
@@ -1,0 +1,91 @@
+/*
+ * Homepage atmospheric refinement
+ *
+ * Adds quiet depth to the al-folio homepage without changing the information
+ * architecture. The visual language is inspired by scientific surfaces:
+ * subtle light fields and observation textures rather than decorative effects.
+ */
+
+.hao-home-page .hao-home--alfolio {
+  position: relative;
+  isolation: isolate;
+}
+
+.hao-home-page .hao-home--alfolio::before {
+  position: absolute;
+  z-index: -1;
+  top: -8rem;
+  right: -8rem;
+  width: 32rem;
+  height: 32rem;
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      circle,
+      color-mix(in srgb, var(--global-theme-color, #2b6cb0) 10%, transparent),
+      transparent 68%
+    );
+  content: "";
+  pointer-events: none;
+}
+
+.hao-home-page .hao-home-intro {
+  position: relative;
+}
+
+.hao-home-page .hao-home-intro::before {
+  position: absolute;
+  z-index: -1;
+  top: -2rem;
+  left: -2rem;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--global-theme-color, #2b6cb0) 5%, transparent),
+    transparent 72%
+  );
+  content: "";
+  pointer-events: none;
+}
+
+/* Low contrast observation-grid texture: closer to geospatial data surfaces than tech decoration. */
+.hao-home-page .hao-home-section {
+  position: relative;
+}
+
+.hao-home-page .hao-home-section:nth-of-type(even) {
+  background-image:
+    radial-gradient(
+      color-mix(in srgb, var(--global-text-color, #111827) 7%, transparent) 0.7px,
+      transparent 0.7px
+    );
+  background-position: center;
+  background-size: 28px 28px;
+}
+
+.hao-home-page .post > article > .profile img {
+  border-radius: 1rem;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hao-home-page .hao-home--alfolio::before,
+  .hao-home-page .hao-home-intro::before {
+    display: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .hao-home-page .hao-home--alfolio::before {
+    top: -4rem;
+    right: -12rem;
+    width: 22rem;
+    height: 22rem;
+  }
+
+  .hao-home-page .hao-home-intro::before {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

Introduce a restrained visual refinement layer for the homepage after the structural redesign.

### Changes
- add `hao-home-atmosphere.css` as a homepage-only visual layer
- introduce subtle radial light fields around the hero composition
- add very low-contrast scientific observation texture to selected sections
- refine profile image integration with softer rounding and shadow
- keep the al-folio structure, homepage information architecture, and secondary pages unchanged

## Design rationale

The goal is quiet depth rather than decorative styling:

- scientific portfolio, not AI startup aesthetics
- geospatial/data texture rather than generic tech patterns
- minimal visual interference with research content

## Scope

Only homepage assets are affected through `SiteVisualPolish::HOMEPAGE_STYLESHEETS`.

No changes to CV, repositories, blog, or project pages.
