### PR TITLE
feat: expose deployed build and restore portfolio layout

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module SiteVisualPolish
-  # Keep the starter close to upstream al-folio by default. The homepage owns one
-  # scoped layout stylesheet; CV and Repositories own narrow component layers.
+  # Keep the starter close to upstream al-folio by default. Each customized
+  # surface owns one narrowly scoped stylesheet and body class.
   HOMEPAGE_STYLESHEETS = [
     "hao-home-center-fix.css",
     "hao-home-atmosphere.css"
@@ -16,7 +16,11 @@ module SiteVisualPolish
     "repositories-page-polish.css"
   ].freeze
 
-  STYLESHEET_VERSION = "20260803-cv-toc-home-81".freeze
+  PORTFOLIO_STYLESHEETS = [
+    "portfolio-page-polish.css"
+  ].freeze
+
+  STYLESHEET_VERSION = "20260803-portfolio-build".freeze
 
   def self.cv_page?(page)
     page.relative_path == "cv.md" || page.url.to_s == "/cv/"
@@ -24,6 +28,10 @@ module SiteVisualPolish
 
   def self.repositories_page?(page)
     page.relative_path == "_pages/repositories.md" || page.url.to_s == "/repositories/"
+  end
+
+  def self.portfolio_page?(page)
+    page.relative_path == "_pages/portfolio.md" || page.url.to_s == "/portfolio/"
   end
 
   def self.apply_cv_title(page)
@@ -61,6 +69,13 @@ module SiteVisualPolish
     page.output = page.output.sub('<body class="', '<body class="hao-repositories-page ')
   end
 
+  def self.apply_portfolio_body_class(page)
+    return unless portfolio_page?(page)
+    return if page.output.include?("hao-portfolio-page")
+
+    page.output = page.output.sub('<body class="', '<body class="hao-portfolio-page ')
+  end
+
   def self.apply_home_navbar_brand(page)
     return unless home_page?(page)
     return unless page.output.include?("hao-home--alfolio")
@@ -73,6 +88,30 @@ module SiteVisualPolish
 
     navbar_container = %r{(<nav[^>]*class="[^"]*\bnavbar\b[^"]*"[^>]*>\s*<div[^>]*class="[^"]*\bcontainer(?:-fluid)?\b[^"]*"[^>]*>)}m
     page.output = page.output.sub(navbar_container, "\\1\n      #{brand}")
+  end
+
+  def self.build_revision(page)
+    revision = ENV["GITHUB_SHA"].to_s
+    revision = page.site.config.dig("github", "build_revision").to_s if revision.empty?
+    revision = ENV["JEKYLL_BUILD_REVISION"].to_s if revision.empty?
+    revision.match?(/\A[0-9a-f]{7,40}\z/i) ? revision.downcase : nil
+  end
+
+  def self.apply_footer_build_revision(page)
+    revision = build_revision(page)
+    return unless revision
+    return if page.output.include?("hao-build-revision")
+
+    short_revision = revision[0, 7]
+    repo_url = page.site.config.dig("github", "repository_url").to_s
+    repo_url = "https://github.com/liuh886/notes" if repo_url.empty?
+    build_url = "#{repo_url.sub(%r{/$}, '')}/commit/#{revision}"
+    markup = %( <span class="hao-build-revision" data-build-revision="#{revision}" title="Deployed Git commit #{revision}">· Build <a href="#{build_url}" rel="noopener noreferrer">#{short_revision}</a></span>)
+
+    footer_pattern = %r{(<footer\b[^>]*role="contentinfo"[^>]*>.*?<div\b[^>]*class="[^"]*\bcontainer\b[^"]*"[^>]*>)(.*?)(</div>\s*</footer>)}m
+    page.output = page.output.sub(footer_pattern) do
+      "#{Regexp.last_match(1)}#{Regexp.last_match(2).rstrip}#{markup}\n#{Regexp.last_match(3)}"
+    end
   end
 
   def self.apply_stylesheets(page, stylesheets)
@@ -106,6 +145,12 @@ module SiteVisualPolish
 
     apply_stylesheets(page, REPOSITORIES_STYLESHEETS)
   end
+
+  def self.apply_portfolio_stylesheet(page)
+    return unless portfolio_page?(page)
+
+    apply_stylesheets(page, PORTFOLIO_STYLESHEETS)
+  end
 end
 
 [:pages, :documents].each do |hook_owner|
@@ -114,9 +159,12 @@ end
     SiteVisualPolish.apply_home_body_class(page)
     SiteVisualPolish.apply_cv_body_class(page)
     SiteVisualPolish.apply_repositories_body_class(page)
+    SiteVisualPolish.apply_portfolio_body_class(page)
     SiteVisualPolish.apply_home_navbar_brand(page)
     SiteVisualPolish.apply_homepage_stylesheet(page)
     SiteVisualPolish.apply_cv_stylesheet(page)
     SiteVisualPolish.apply_repositories_stylesheet(page)
+    SiteVisualPolish.apply_portfolio_stylesheet(page)
+    SiteVisualPolish.apply_footer_build_revision(page)
   end
 end

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -24,7 +24,7 @@ module SiteVisualPolish
     "portfolio-page-polish.css"
   ].freeze
 
-  STYLESHEET_VERSION = "20260803-portfolio-build".freeze
+  STYLESHEET_VERSION = "20260803-cv-toc-home-81".freeze
 
   def self.cv_page?(page)
     page.relative_path == "cv.md" || page.url.to_s == "/cv/"

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -3,6 +3,10 @@
 module SiteVisualPolish
   # Keep the starter close to upstream al-folio by default. Each customized
   # surface owns one narrowly scoped stylesheet and body class.
+  GLOBAL_STYLESHEETS = [
+    "footer-build.css"
+  ].freeze
+
   HOMEPAGE_STYLESHEETS = [
     "hao-home-center-fix.css",
     "hao-home-atmosphere.css"
@@ -90,6 +94,17 @@ module SiteVisualPolish
     page.output = page.output.sub(navbar_container, "\\1\n      #{brand}")
   end
 
+  def self.apply_home_portfolio_link(page)
+    return unless home_page?(page)
+    return if page.output.include?('data-hao-portfolio-link="true"')
+
+    baseurl = page.site.config["baseurl"].to_s.sub(%r{/$}, "")
+    href = baseurl.empty? ? "/portfolio/" : "#{baseurl}/portfolio/"
+    link = %(<a href="#{href}" data-hao-portfolio-link="true">Portfolio</a>)
+    contact_links = %r{(<div class="hao-home-contact-links">.*?)(\s*</div>)}m
+    page.output = page.output.sub(contact_links, "\\1\n      #{link}\\2")
+  end
+
   def self.build_revision(page)
     revision = ENV["GITHUB_SHA"].to_s
     revision = page.site.config.dig("github", "build_revision").to_s if revision.empty?
@@ -128,6 +143,10 @@ module SiteVisualPolish
     end
   end
 
+  def self.apply_global_stylesheet(page)
+    apply_stylesheets(page, GLOBAL_STYLESHEETS)
+  end
+
   def self.apply_homepage_stylesheet(page)
     return unless home_page?(page)
 
@@ -161,6 +180,8 @@ end
     SiteVisualPolish.apply_repositories_body_class(page)
     SiteVisualPolish.apply_portfolio_body_class(page)
     SiteVisualPolish.apply_home_navbar_brand(page)
+    SiteVisualPolish.apply_home_portfolio_link(page)
+    SiteVisualPolish.apply_global_stylesheet(page)
     SiteVisualPolish.apply_homepage_stylesheet(page)
     SiteVisualPolish.apply_cv_stylesheet(page)
     SiteVisualPolish.apply_repositories_stylesheet(page)

--- a/assets/css/footer-build.css
+++ b/assets/css/footer-build.css
@@ -1,0 +1,23 @@
+/* Compact deployment identifier appended to the inherited al-folio footer. */
+
+.hao-build-revision {
+  display: inline;
+  margin-left: 0.2em;
+  color: inherit;
+  white-space: nowrap;
+}
+
+.hao-build-revision a {
+  color: inherit;
+  font-family: var(--global-code-font, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  text-decoration: none;
+  opacity: 0.78;
+}
+
+.hao-build-revision a:hover,
+.hao-build-revision a:focus-visible {
+  color: var(--global-theme-color);
+  opacity: 1;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}

--- a/assets/css/portfolio-page-polish.css
+++ b/assets/css/portfolio-page-polish.css
@@ -1,0 +1,251 @@
+/*
+ * Portfolio page polish
+ *
+ * Restores structure and responsive behavior to the TradingView-heavy portfolio
+ * page without turning it into a trading-terminal aesthetic. Every selector is
+ * scoped to /portfolio/ through the injected body class.
+ */
+
+.hao-portfolio-page {
+  --hao-portfolio-line: color-mix(in srgb, var(--global-text-color, #111827) 13%, transparent);
+  --hao-portfolio-line-soft: color-mix(in srgb, var(--global-text-color, #111827) 8%, transparent);
+  --hao-portfolio-muted: color-mix(in srgb, var(--global-text-color, #111827) 66%, transparent);
+  --hao-portfolio-surface: var(--global-card-bg-color, var(--global-bg-color, #ffffff));
+  --hao-portfolio-surface-soft: color-mix(in srgb, var(--global-theme-color, #b80fb8) 3%, var(--global-bg-color, #ffffff));
+  --hao-portfolio-radius: 12px;
+  --hao-portfolio-shadow: 0 18px 44px rgba(15, 23, 42, 0.08);
+}
+
+html[data-theme="dark"] .hao-portfolio-page {
+  --hao-portfolio-line: color-mix(in srgb, var(--global-text-color, #f8fafc) 20%, transparent);
+  --hao-portfolio-line-soft: color-mix(in srgb, var(--global-text-color, #f8fafc) 12%, transparent);
+  --hao-portfolio-muted: color-mix(in srgb, var(--global-text-color, #f8fafc) 68%, transparent);
+  --hao-portfolio-surface-soft: color-mix(in srgb, var(--global-theme-color, #b80fb8) 6%, var(--global-bg-color, #111827));
+  --hao-portfolio-shadow: 0 18px 44px rgba(0, 0, 0, 0.28);
+}
+
+.hao-portfolio-page > .container[role="main"] {
+  max-width: 80rem;
+}
+
+.hao-portfolio-page .post-header {
+  max-width: 54rem;
+  margin-bottom: 1rem;
+}
+
+.hao-portfolio-page .post-title {
+  letter-spacing: -0.035em;
+}
+
+.hao-portfolio-page .post-description {
+  max-width: 48rem;
+  color: var(--hao-portfolio-muted);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.hao-portfolio-page article > p,
+.hao-portfolio-page article > ul {
+  max-width: 49rem;
+}
+
+.hao-portfolio-page article > p {
+  color: var(--hao-portfolio-muted);
+  line-height: 1.75;
+}
+
+.hao-portfolio-page article > ul {
+  margin: 1rem 0 2.2rem;
+  padding-left: 1.2rem;
+}
+
+.hao-portfolio-page article > ul li {
+  margin: 0.45rem 0;
+  line-height: 1.65;
+}
+
+.hao-portfolio-page article > hr {
+  margin: 2.4rem 0 2.2rem;
+  border-color: var(--hao-portfolio-line);
+}
+
+.hao-portfolio-page article > h2 {
+  margin: 2.5rem 0 1rem;
+  padding-top: 0;
+  border-top: 0;
+  font-size: clamp(1.45rem, 2vw, 2rem);
+  font-weight: 520;
+  letter-spacing: -0.03em;
+}
+
+.hao-portfolio-page .stock-widget,
+.hao-portfolio-page .portfolio-widgets__top-stories,
+.hao-portfolio-page .portfolio-widgets__analysis {
+  min-width: 0;
+}
+
+.hao-portfolio-page .stock-widget {
+  overflow: hidden;
+  border: 1px solid var(--hao-portfolio-line);
+  border-radius: var(--hao-portfolio-radius);
+  background: linear-gradient(180deg, var(--hao-portfolio-surface), var(--hao-portfolio-surface-soft));
+  box-shadow: none;
+}
+
+.hao-portfolio-page .stock-widget--ticker {
+  padding: 0.35rem;
+}
+
+.hao-portfolio-page .stock-widget--overview {
+  height: clamp(30rem, 60vw, 42rem);
+  padding: 0.45rem;
+}
+
+.hao-portfolio-page .stock-widget--overview > .tradingview-widget-container,
+.hao-portfolio-page .stock-widget--overview .tradingview-widget-container__widget {
+  height: 100%;
+}
+
+.hao-portfolio-page .portfolio-widgets {
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(20rem, 0.92fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.hao-portfolio-page .portfolio-widgets .stock-widget {
+  margin: 0 !important;
+}
+
+.hao-portfolio-page .stock-widget--story,
+.hao-portfolio-page .stock-widget--analysis {
+  min-height: 480px;
+}
+
+.hao-portfolio-page .stock-analysis__selector {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8rem;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid var(--hao-portfolio-line-soft);
+}
+
+.hao-portfolio-page .stock-analysis__label {
+  flex: 0 0 auto;
+  padding-top: 0.3rem;
+  color: var(--hao-portfolio-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.hao-portfolio-page .stock-analysis__buttons {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+
+.hao-portfolio-page .stock-analysis__pill {
+  min-height: 2rem;
+  border: 1px solid var(--hao-portfolio-line);
+  border-radius: 999px;
+  padding: 0.38rem 0.65rem;
+  background: var(--hao-portfolio-surface);
+  color: var(--hao-portfolio-muted);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.hao-portfolio-page .stock-analysis__pill:hover,
+.hao-portfolio-page .stock-analysis__pill:focus-visible,
+.hao-portfolio-page .stock-analysis__pill.is-active {
+  border-color: color-mix(in srgb, var(--global-theme-color) 55%, var(--hao-portfolio-line));
+  background: var(--hao-portfolio-surface-soft);
+  color: var(--global-theme-color);
+}
+
+.hao-portfolio-page .stock-analysis__pill:focus-visible {
+  outline: 2px solid var(--global-theme-color);
+  outline-offset: 2px;
+}
+
+.hao-portfolio-page .stock-analysis__panel {
+  display: none;
+}
+
+.hao-portfolio-page .stock-analysis__panel.is-active {
+  display: block;
+}
+
+html[data-theme="dark"] .hao-portfolio-page .stock-widget-light,
+html:not([data-theme="dark"]) .hao-portfolio-page .stock-widget-dark {
+  display: none !important;
+}
+
+.hao-portfolio-page .tradingview-widget-container,
+.hao-portfolio-page .tradingview-widget-container__widget {
+  width: 100% !important;
+  max-width: 100%;
+}
+
+.hao-portfolio-page .hao-build-revision {
+  white-space: nowrap;
+}
+
+.hao-build-revision {
+  display: inline;
+  margin-left: 0.2em;
+  color: inherit;
+  white-space: nowrap;
+}
+
+.hao-build-revision a {
+  color: inherit;
+  font-family: var(--global-code-font, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  text-decoration: none;
+  opacity: 0.8;
+}
+
+.hao-build-revision a:hover,
+.hao-build-revision a:focus-visible {
+  color: var(--global-theme-color);
+  opacity: 1;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+@media (max-width: 992px) {
+  .hao-portfolio-page .portfolio-widgets {
+    grid-template-columns: 1fr;
+  }
+
+  .hao-portfolio-page .stock-widget--overview {
+    height: 34rem;
+  }
+}
+
+@media (max-width: 576px) {
+  .hao-portfolio-page .stock-widget--overview {
+    height: 29rem;
+  }
+
+  .hao-portfolio-page .stock-analysis__selector {
+    display: block;
+  }
+
+  .hao-portfolio-page .stock-analysis__label {
+    display: block;
+    margin-bottom: 0.6rem;
+    padding-top: 0;
+  }
+
+  .hao-portfolio-page .stock-widget--story,
+  .hao-portfolio-page .stock-widget--analysis {
+    min-height: 440px;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "lint:prettier": "prettier . --check",
-    "lint:style-contract": "node test/style_contract.js && node test/repositories_contract.js",
+    "lint:style-contract": "node test/style_contract.js && node test/repositories_contract.js && node test/portfolio_contract.js",
     "test:visual": "playwright test --config test/visual/playwright.config.js",
     "test:visual:update": "playwright test --config test/visual/playwright.config.js --update-snapshots"
   },

--- a/test/portfolio_contract.js
+++ b/test/portfolio_contract.js
@@ -1,0 +1,94 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireIncludes = (source, values, label) => {
+  for (const value of values) {
+    if (!source.includes(value)) {
+      failures.push(`${label} must include: \`${value}\`.`);
+    }
+  }
+};
+
+const requireAbsent = (source, values, label) => {
+  for (const value of values) {
+    if (source.includes(value)) {
+      failures.push(`${label} must not include: \`${value}\`.`);
+    }
+  }
+};
+
+const plugin = read("_plugins/site_visual_polish.rb");
+requireIncludes(
+  plugin,
+  [
+    "GLOBAL_STYLESHEETS",
+    "footer-build.css",
+    "PORTFOLIO_STYLESHEETS",
+    "portfolio-page-polish.css",
+    "def self.portfolio_page?(page)",
+    "def self.apply_portfolio_body_class(page)",
+    "hao-portfolio-page",
+    "def self.apply_home_portfolio_link(page)",
+    'data-hao-portfolio-link="true"',
+    "def self.build_revision(page)",
+    'ENV["GITHUB_SHA"]',
+    "def self.apply_footer_build_revision(page)",
+    "hao-build-revision",
+    "· Build",
+    "def self.apply_portfolio_stylesheet(page)",
+  ],
+  "Site visual polish plugin",
+);
+
+const portfolioCss = read("assets/css/portfolio-page-polish.css");
+requireIncludes(
+  portfolioCss,
+  [
+    ".hao-portfolio-page .portfolio-widgets",
+    "grid-template-columns: minmax(0, 1.08fr) minmax(20rem, 0.92fr)",
+    ".hao-portfolio-page .stock-widget--overview",
+    ".hao-portfolio-page .stock-analysis__pill",
+    ".hao-portfolio-page .stock-analysis__panel.is-active",
+    'html[data-theme="dark"] .hao-portfolio-page .stock-widget-light',
+    'html:not([data-theme="dark"]) .hao-portfolio-page .stock-widget-dark',
+    "@media (max-width: 992px)",
+  ],
+  "Portfolio stylesheet",
+);
+requireAbsent(
+  portfolioCss,
+  ["body:has(", "position: fixed", "overflow-x: scroll"],
+  "Portfolio stylesheet",
+);
+
+const footerCss = read("assets/css/footer-build.css");
+requireIncludes(
+  footerCss,
+  [".hao-build-revision", ".hao-build-revision a", "white-space: nowrap"],
+  "Footer build stylesheet",
+);
+
+const portfolioPage = read("_pages/portfolio.md");
+requireIncludes(
+  portfolioPage,
+  [
+    "permalink: /portfolio/",
+    "stock-widget--ticker",
+    "stock-widget--overview",
+    "portfolio-widgets",
+    "stock-analysis__selector",
+  ],
+  "Portfolio page",
+);
+
+if (failures.length > 0) {
+  console.error("Portfolio and deployment contract check failed:");
+  failures.forEach((message) => console.error(`- ${message}`));
+  process.exit(1);
+}
+
+console.log("Portfolio and deployment contract check passed.");


### PR DESCRIPTION
## Summary

Two coordinated workstreams improve deployment observability and the personal portfolio surface.

### Deployment metadata
- append a compact `· Build <sha>` identifier to the inherited al-folio footer
- derive the revision automatically from `GITHUB_SHA`, with Jekyll metadata fallbacks
- link the seven-character revision to the corresponding GitHub commit
- load a minimal global stylesheet only for the build identifier

### Homepage and Portfolio
- append `Portfolio` as the final link in the homepage Contact row
- add a `/portfolio/`-only body scope and stylesheet
- restore TradingView light/dark selection, chart heights, card containment, technical-analysis tabs, responsive two-column layout, and mobile stacking
- preserve the existing market-observation content and widget data instead of replacing it with a trading-dashboard redesign

## Architecture
- no `_includes` override: the footer remains owned by the al-folio theme and is augmented post-render
- all Portfolio selectors are scoped through `.hao-portfolio-page`
- Blog, CV, Repositories, Projects, and Publications retain their existing layouts

## Validation
- existing frontend contracts
- new portfolio/deployment contract
- Ruby syntax and production Jekyll build through the current deploy workflow
