### PR TITLE
fix: update public contact email

### DIFF
--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -1,7 +1,7 @@
 cv:
   name: Zhihao LIU
   label: Climate & Energy Data Scientist
-  email: zhihaol[at]uio.com
+  email: liuzhihao109[at]foxmail.com
   location: Oslo / Bergen, Norway
   image: ""
 


### PR DESCRIPTION
## Summary

- replace the CV contact email `zhihaol[at]uio.com`
- use `liuzhihao109[at]foxmail.com` instead
- preserve the existing obfuscated display format

## Scope

Only `_data/cv.yml` changes; no layout or visual behavior is affected.