### PR TITLE
fix: align Current work texture and hero transition

### DIFF
--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -9,7 +9,8 @@ module SiteVisualPolish
 
   HOMEPAGE_STYLESHEETS = [
     "hao-home-center-fix.css",
-    "hao-home-atmosphere-v2.css"
+    "hao-home-atmosphere-v2.css",
+    "hao-home-current-work-texture-fix.css"
   ].freeze
 
   CV_STYLESHEETS = [
@@ -24,7 +25,7 @@ module SiteVisualPolish
     "portfolio-page-polish.css"
   ].freeze
 
-  STYLESHEET_VERSION = "20260803-cv-toc-home-81".freeze
+  STYLESHEET_VERSION = "20260803-current-work-texture".freeze
 
   def self.cv_page?(page)
     page.relative_path == "cv.md" || page.url.to_s == "/cv/"

--- a/_plugins/site_visual_polish.rb
+++ b/_plugins/site_visual_polish.rb
@@ -25,7 +25,7 @@ module SiteVisualPolish
     "portfolio-page-polish.css"
   ].freeze
 
-  STYLESHEET_VERSION = "20260803-current-work-texture".freeze
+  STYLESHEET_VERSION = "20260803-cv-toc-home-81".freeze
 
   def self.cv_page?(page)
     page.relative_path == "cv.md" || page.url.to_s == "/cv/"

--- a/assets/css/hao-home-current-work-texture-fix.css
+++ b/assets/css/hao-home-current-work-texture-fix.css
@@ -1,0 +1,54 @@
+/*
+ * Current work scientific texture visibility correction
+ *
+ * The first v2 texture was technically present but sat on a negative layer and
+ * used sub-pixel marks at very low contrast. This correction keeps the texture
+ * restrained while ensuring it survives high-DPI rendering and remains visible
+ * in the open space around the Current work cards.
+ */
+
+.hao-home-page #current-work {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.hao-home-page #current-work::before {
+  z-index: 0;
+  background-image:
+    radial-gradient(
+      circle at 78% 20%,
+      color-mix(in srgb, var(--global-theme-color, #b80fb8) 8%, transparent),
+      transparent 40%
+    ),
+    repeating-radial-gradient(
+      ellipse at 94% 78%,
+      transparent 0 2.55rem,
+      color-mix(in srgb, var(--global-theme-color, #b80fb8) 9%, transparent) 2.62rem 2.7rem,
+      transparent 2.77rem 4.95rem
+    ),
+    radial-gradient(
+      color-mix(in srgb, var(--global-text-color, #111827) 11%, transparent) 0.9px,
+      transparent 1.05px
+    );
+  background-position: center, center, 0 0;
+  background-size: auto, auto, 26px 26px;
+  opacity: 0.9;
+}
+
+.hao-home-page #current-work > * {
+  position: relative;
+  z-index: 1;
+}
+
+html[data-theme="dark"] .hao-home-page #current-work::before {
+  opacity: 0.82;
+}
+
+@media (max-width: 760px) {
+  .hao-home-page #current-work::before {
+    background-position: center, 7rem 2rem, 0 0;
+    background-size: auto, auto, 24px 24px;
+    opacity: 0.58;
+  }
+}

--- a/assets/css/hao-home-current-work-texture-fix.css
+++ b/assets/css/hao-home-current-work-texture-fix.css
@@ -1,10 +1,9 @@
 /*
  * Current work scientific texture visibility correction
  *
- * The first v2 texture was technically present but sat on a negative layer and
- * used sub-pixel marks at very low contrast. This correction keeps the texture
- * restrained while ensuring it survives high-DPI rendering and remains visible
- * in the open space around the Current work cards.
+ * Keep Current work on the same scientific-texture scale and contrast as the
+ * later homepage sections, while extending the hero's purple ambient field into
+ * the top of the section so the transition reads as one continuous composition.
  */
 
 .hao-home-page #current-work {
@@ -16,24 +15,40 @@
 .hao-home-page #current-work::before {
   z-index: 0;
   background-image:
-    radial-gradient(
-      circle at 78% 20%,
-      color-mix(in srgb, var(--global-theme-color, #b80fb8) 8%, transparent),
-      transparent 40%
-    ),
     repeating-radial-gradient(
-      ellipse at 94% 78%,
-      transparent 0 2.55rem,
-      color-mix(in srgb, var(--global-theme-color, #b80fb8) 9%, transparent) 2.62rem 2.7rem,
-      transparent 2.77rem 4.95rem
+      ellipse at 92% 72%,
+      transparent 0 2.8rem,
+      color-mix(in srgb, var(--global-theme-color, #b80fb8) 6%, transparent) 2.85rem 2.91rem,
+      transparent 2.96rem 5.1rem
     ),
     radial-gradient(
-      color-mix(in srgb, var(--global-text-color, #111827) 11%, transparent) 0.9px,
-      transparent 1.05px
+      color-mix(in srgb, var(--global-text-color, #111827) 6%, transparent) 0.7px,
+      transparent 0.8px
     );
-  background-position: center, center, 0 0;
-  background-size: auto, auto, 26px 26px;
-  opacity: 0.9;
+  background-position: center, 0 0;
+  background-size: auto, 56px 56px;
+  opacity: 0.58;
+}
+
+.hao-home-page #current-work::after {
+  position: absolute;
+  z-index: 0;
+  top: -8rem;
+  right: -5rem;
+  width: 36rem;
+  height: 22rem;
+  border-radius: 50%;
+  background: radial-gradient(
+    ellipse at 62% 0%,
+    color-mix(in srgb, var(--global-theme-color, #b80fb8) 9%, transparent),
+    color-mix(in srgb, var(--global-theme-color, #b80fb8) 4%, transparent) 42%,
+    transparent 72%
+  );
+  content: "";
+  opacity: 0.68;
+  pointer-events: none;
+  transform-origin: 62% 0%;
+  animation: hao-home-ambient-breathe 16s ease-in-out infinite alternate;
 }
 
 .hao-home-page #current-work > * {
@@ -42,13 +57,31 @@
 }
 
 html[data-theme="dark"] .hao-home-page #current-work::before {
-  opacity: 0.82;
+  opacity: 0.72;
+}
+
+html[data-theme="dark"] .hao-home-page #current-work::after {
+  opacity: 0.76;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hao-home-page #current-work::after {
+    animation: none;
+  }
 }
 
 @media (max-width: 760px) {
   .hao-home-page #current-work::before {
-    background-position: center, 7rem 2rem, 0 0;
-    background-size: auto, auto, 24px 24px;
-    opacity: 0.58;
+    background-position: 5rem 1rem, 0 0;
+    background-size: auto, 56px 56px;
+    opacity: 0.44;
+  }
+
+  .hao-home-page #current-work::after {
+    top: -6rem;
+    right: -10rem;
+    width: 26rem;
+    height: 18rem;
+    opacity: 0.48;
   }
 }

--- a/test/home_atmosphere_contract.js
+++ b/test/home_atmosphere_contract.js
@@ -64,17 +64,27 @@ requireIncludes(
   [
     "Current work scientific texture visibility correction",
     ".hao-home-page #current-work::before",
+    ".hao-home-page #current-work::after",
     "z-index: 0",
     "repeating-radial-gradient",
+    "background-size: auto, 56px 56px",
+    "opacity: 0.58",
+    "animation: hao-home-ambient-breathe 16s",
+    "@media (prefers-reduced-motion: reduce)",
     ".hao-home-page #current-work > *",
     "z-index: 1",
-    "0.9px",
   ],
   "Current work texture correction",
 );
 requireAbsent(
   currentWorkFix,
-  ["position: fixed", "backdrop-filter", "mix-blend-mode"],
+  [
+    "position: fixed",
+    "backdrop-filter",
+    "mix-blend-mode",
+    "background-size: auto, auto, 26px 26px",
+    "opacity: 0.9",
+  ],
   "Current work texture correction",
 );
 

--- a/test/home_atmosphere_contract.js
+++ b/test/home_atmosphere_contract.js
@@ -24,7 +24,11 @@ const requireAbsent = (source, values, label) => {
 const plugin = read("_plugins/site_visual_polish.rb");
 requireIncludes(
   plugin,
-  ["hao-home-center-fix.css", "hao-home-atmosphere-v2.css"],
+  [
+    "hao-home-center-fix.css",
+    "hao-home-atmosphere-v2.css",
+    "hao-home-current-work-texture-fix.css",
+  ],
   "Homepage stylesheet registration",
 );
 requireAbsent(plugin, ["hao-home-atmosphere.css"], "Homepage stylesheet registration");
@@ -52,6 +56,26 @@ requireAbsent(
   css,
   ["position: fixed", "animation-duration: 1s", "filter: hue-rotate", "backdrop-filter"],
   "Homepage atmosphere stylesheet",
+);
+
+const currentWorkFix = read("assets/css/hao-home-current-work-texture-fix.css");
+requireIncludes(
+  currentWorkFix,
+  [
+    "Current work scientific texture visibility correction",
+    ".hao-home-page #current-work::before",
+    "z-index: 0",
+    "repeating-radial-gradient",
+    ".hao-home-page #current-work > *",
+    "z-index: 1",
+    "0.9px",
+  ],
+  "Current work texture correction",
+);
+requireAbsent(
+  currentWorkFix,
+  ["position: fixed", "backdrop-filter", "mix-blend-mode"],
+  "Current work texture correction",
 );
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Summary

- correct the Current work texture layer so it renders above the section background instead of disappearing on a negative stacking layer
- match the later homepage sections at the same 56 px scientific-texture scale and restrained contrast
- retain a distinct observation-point pattern without making Current work denser or stronger than Projects & code / Notes & publications
- extend the hero's purple ambient field into the upper edge of Current work with the same slow breathing motion
- allow the purple ambient field to drift slowly across the hero-to-Current work boundary instead of using a fixed position
- keep that purple field only as a transition band, rather than turning the whole section into another hero surface
- keep all content above the visual layers and preserve dark mode, mobile behavior, and `prefers-reduced-motion`
- add an explicit atmosphere contract for texture scale, contrast, stacking, and motion continuity

## Scope

Homepage Current work and the hero-to-content transition only. No information architecture or secondary-page changes.