### PR TITLE
content: expose live apps and add NewsFlow

### DIFF
--- a/_data/current_operations.yml
+++ b/_data/current_operations.yml
@@ -31,7 +31,9 @@ operations:
     summary: Lightweight rhythm and speech-practice tool for focused review sessions. Current work is content structure, subtle pronunciation marks, and PWA training flow.
     href: https://liuh886.github.io/RhythmCoach/
     label: Open app
-  - id: OP-06
+
+upcoming:
+  - id: NEXT-01
     title: NewsFlow
     status: COMING SOON
     summary: An upcoming product now entering active build. The repository is public; the app link and fuller product record will be added after the first usable release is ready.

--- a/_data/current_operations.yml
+++ b/_data/current_operations.yml
@@ -15,8 +15,10 @@ operations:
     title: AlphaEngine
     status: RESEARCH ENGINE
     summary: Experimental research platform for data foundations, factor panels, model training, and reproducible strategy records across selected US and China pools.
-    href: https://github.com/liuh886/alpha_engine
-    label: View repository
+    href: https://liuh886.github.io/alpha_engine/
+    label: Open app
+    secondary_href: https://github.com/liuh886/alpha_engine
+    secondary_label: Repository
   - id: OP-04
     title: FlappyK
     status: LIVE ITERATION
@@ -29,6 +31,12 @@ operations:
     summary: Lightweight rhythm and speech-practice tool for focused review sessions. Current work is content structure, subtle pronunciation marks, and PWA training flow.
     href: https://liuh886.github.io/RhythmCoach/
     label: Open app
+  - id: OP-06
+    title: NewsFlow
+    status: COMING SOON
+    summary: An upcoming product now entering active build. The repository is public; the app link and fuller product record will be added after the first usable release is ready.
+    href: https://github.com/liuh886/NewsFlow
+    label: Follow build
 
 dispatches:
   - date: 2026-08-02

--- a/_data/selected_deployments.yml
+++ b/_data/selected_deployments.yml
@@ -16,17 +16,23 @@ groups:
         status: PLATFORM
         kind: Offshore energy / marine intelligence
         summary: A partner-facing offshore energy and marine intelligence portal supported by a reproducible content and presentation pipeline.
-        href: /projects/2026_oceanhub/
-        primary_label: View project
+        href: https://liuh886.github.io/oceanhub/
+        primary_label: Open app
+        secondary_href: /projects/2026_oceanhub/
+        secondary_label: Project record
+        repository_href: https://github.com/liuh886/OceanHub
+        repository_label: Repository
       - ref: P-03
-        title: 4D Seismic
+        title: 4D Seismic Hub
         status: KNOWLEDGE PRODUCT
         kind: Time-lapse seismic / monitoring
         summary: A curated knowledge hub that organizes 4D seismic best practices and case studies for early-stage technical screening.
-        href: /projects/2025_4d_seismic/
-        primary_label: View project
-        secondary_href: https://github.com/liuh886/4d-seismic-hub
-        secondary_label: Repository
+        href: https://liuh886.github.io/4d-seismic-hub/
+        primary_label: Open app
+        secondary_href: /projects/2025_4d_seismic/
+        secondary_label: Project record
+        repository_href: https://github.com/liuh886/4d-seismic-hub
+        repository_label: Repository
       - ref: P-04
         title: Climate-to-energy downscaling
         status: RESEARCH PROJECT

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -52,8 +52,8 @@ home_cta: false
   <section class="hao-home-section" id="current-work" aria-labelledby="current-work-title">
     <div class="hao-home-section-header">
       <p class="hao-home-eyebrow">Current work</p>
-      <h2 id="current-work-title">Six maintained product and research lanes.</h2>
-      <p>This section is limited to work that is actively maintained or being prepared for its first public release. Archived projects and supporting tools appear separately below.</p>
+      <h2 id="current-work-title">Five maintained product and research lanes.</h2>
+      <p>Five active systems are maintained now; the final card shows the next product entering build. Archived projects and supporting tools appear separately below.</p>
     </div>
     <div class="hao-home-card-grid">
       {% for operation in site.data.current_operations.operations %}
@@ -72,6 +72,19 @@ home_cta: false
               <a class="hao-home-text-link" href="{{ operation.secondary_href }}" target="_blank" rel="noopener noreferrer">{{ operation.secondary_label | default: "Repository" }} →</a>
             {% endif %}
           </div>
+        </article>
+      {% endfor %}
+      {% for upcoming in site.data.current_operations.upcoming %}
+        <article class="hao-home-card">
+          <div class="hao-home-card-topline">
+            <span>{{ upcoming.id }}</span>
+            <strong>{{ upcoming.status }}</strong>
+          </div>
+          <h3>{{ upcoming.title }}</h3>
+          <p>{{ upcoming.summary }}</p>
+          {% if upcoming.href %}
+            <a class="hao-home-text-link" href="{{ upcoming.href }}" target="_blank" rel="noopener noreferrer">{{ upcoming.label | default: "Follow build" }} →</a>
+          {% endif %}
         </article>
       {% endfor %}
     </div>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -52,8 +52,8 @@ home_cta: false
   <section class="hao-home-section" id="current-work" aria-labelledby="current-work-title">
     <div class="hao-home-section-header">
       <p class="hao-home-eyebrow">Current work</p>
-      <h2 id="current-work-title">Five maintained product and research lanes.</h2>
-      <p>This section is limited to work that is actively maintained now. Archived projects and supporting tools appear separately below.</p>
+      <h2 id="current-work-title">Six maintained product and research lanes.</h2>
+      <p>This section is limited to work that is actively maintained or being prepared for its first public release. Archived projects and supporting tools appear separately below.</p>
     </div>
     <div class="hao-home-card-grid">
       {% for operation in site.data.current_operations.operations %}
@@ -64,9 +64,14 @@ home_cta: false
           </div>
           <h3>{{ operation.title }}</h3>
           <p>{{ operation.summary }}</p>
-          {% if operation.href %}
-            <a class="hao-home-text-link" href="{{ operation.href }}" target="_blank" rel="noopener noreferrer">{{ operation.label | default: "Open" }} →</a>
-          {% endif %}
+          <div class="hao-home-links">
+            {% if operation.href %}
+              <a class="hao-home-text-link" href="{{ operation.href }}" target="_blank" rel="noopener noreferrer">{{ operation.label | default: "Open" }} →</a>
+            {% endif %}
+            {% if operation.secondary_href %}
+              <a class="hao-home-text-link" href="{{ operation.secondary_href }}" target="_blank" rel="noopener noreferrer">{{ operation.secondary_label | default: "Repository" }} →</a>
+            {% endif %}
+          </div>
         </article>
       {% endfor %}
     </div>
@@ -99,10 +104,13 @@ home_cta: false
                 <p>{{ deployment.summary }}</p>
                 <div class="hao-home-links">
                   {% if deployment.href %}
-                    <a class="hao-home-text-link" href="{{ deployment.href }}">{{ deployment.primary_label | default: "Open" }} →</a>
+                    <a class="hao-home-text-link" href="{{ deployment.href }}" {% if deployment.href contains 'http' %}target="_blank" rel="noopener noreferrer"{% endif %}>{{ deployment.primary_label | default: "Open" }} →</a>
                   {% endif %}
                   {% if deployment.secondary_href %}
-                    <a class="hao-home-text-link" href="{{ deployment.secondary_href }}" target="_blank" rel="noopener noreferrer">{{ deployment.secondary_label | default: "Repository" }} →</a>
+                    <a class="hao-home-text-link" href="{{ deployment.secondary_href }}" {% if deployment.secondary_href contains 'http' %}target="_blank" rel="noopener noreferrer"{% endif %}>{{ deployment.secondary_label | default: "More" }} →</a>
+                  {% endif %}
+                  {% if deployment.repository_href %}
+                    <a class="hao-home-text-link" href="{{ deployment.repository_href }}" target="_blank" rel="noopener noreferrer">{{ deployment.repository_label | default: "Repository" }} →</a>
                   {% endif %}
                 </div>
               </article>

--- a/_projects/2026_oceanhub.md
+++ b/_projects/2026_oceanhub.md
@@ -12,9 +12,24 @@ category: work
 > - **Problem:** Offshore projects often have fragmented stakeholders, unclear narratives, and slow partner onboarding.
 > - **Data:** Markdown-first focus areas and insights, maintained as a structured content collection.
 > - **Method:** Astro + Tailwind site with typed content collections; automated partner deck generation from source content.
-> - **Output:** A platform-style portal prototype + a reusable partner introduction deck (v1).
+> - **Output:** A live platform-style portal plus a reusable partner introduction deck pipeline.
 > - **Impact:** Faster alignment across ecosystem partners and a repeatable workflow to publish updates consistently.
-> - **Links:** Public reference: [SBGf Rio 25 OceanHub](https://rio25.sbgf.org.br/Pages/oceanHub.php) (conference page).
+> - **Links:** [Open OceanHub](https://liuh886.github.io/oceanhub/) · [Source code](https://github.com/liuh886/OceanHub) · [SBGf Rio 25 reference](https://rio25.sbgf.org.br/Pages/oceanHub.php)
+
+<div class="row mt-3">
+    <div class="col-sm mt-3 mt-md-0">
+        <a href="https://liuh886.github.io/oceanhub/" target="_blank" class="btn btn-primary w-100">
+            <i class="fa-solid fa-arrow-up-right-from-square"></i> Open OceanHub
+        </a>
+    </div>
+    <div class="col-sm mt-3 mt-md-0">
+        <a href="https://github.com/liuh886/OceanHub" target="_blank" class="btn btn-outline-secondary w-100">
+            <i class="fa-brands fa-github"></i> View Source Code
+        </a>
+    </div>
+</div>
+
+<br>
 
 ## What I built
 
@@ -30,4 +45,3 @@ Key components:
 - **Frontend:** Astro (static-first) + Tailwind CSS, with React used only where needed.
 - **Content model:** type-safe content collections under `src/content/` (Focus Areas, Insights, Case Studies).
 - **Deck pipeline:** scripts that transform curated narrative into a partner deck artifact (PPTX) for repeatable partner onboarding.
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "lint:prettier": "prettier . --check",
-    "lint:style-contract": "node test/style_contract.js && node test/repositories_contract.js && node test/portfolio_contract.js && node test/home_atmosphere_contract.js",
+    "lint:style-contract": "node test/style_contract.js && node test/repositories_contract.js && node test/portfolio_contract.js && node test/home_atmosphere_contract.js && node test/home_content_contract.js",
     "test:visual": "playwright test --config test/visual/playwright.config.js",
     "test:visual:update": "playwright test --config test/visual/playwright.config.js --update-snapshots"
   },

--- a/test/home_content_contract.js
+++ b/test/home_content_contract.js
@@ -1,0 +1,88 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+const failures = [];
+
+const requireIncludes = (source, values, label) => {
+  for (const value of values) {
+    if (!source.includes(value)) {
+      failures.push(`${label} must include: \`${value}\`.`);
+    }
+  }
+};
+
+const requireAbsent = (source, values, label) => {
+  for (const value of values) {
+    if (source.includes(value)) {
+      failures.push(`${label} must not include: \`${value}\`.`);
+    }
+  }
+};
+
+const about = read("_pages/about.md");
+requireIncludes(
+  about,
+  [
+    "Six maintained product and research lanes.",
+    "operation.secondary_href",
+    "deployment.repository_href",
+    "deployment.href contains 'http'",
+  ],
+  "Homepage content template",
+);
+requireAbsent(about, ["Five maintained product and research lanes."], "Homepage content template");
+
+const operations = read("_data/current_operations.yml");
+requireIncludes(
+  operations,
+  [
+    "title: AlphaEngine",
+    "href: https://liuh886.github.io/alpha_engine/",
+    "secondary_href: https://github.com/liuh886/alpha_engine",
+    "title: NewsFlow",
+    "status: COMING SOON",
+    "href: https://github.com/liuh886/NewsFlow",
+  ],
+  "Current operations data",
+);
+requireAbsent(
+  operations,
+  ["href: https://github.com/liuh886/alpha_engine\n    label: View repository"],
+  "Current operations data",
+);
+
+const deployments = read("_data/selected_deployments.yml");
+requireIncludes(
+  deployments,
+  [
+    "title: OceanHub",
+    "href: https://liuh886.github.io/oceanhub/",
+    "repository_href: https://github.com/liuh886/OceanHub",
+    "title: 4D Seismic Hub",
+    "href: https://liuh886.github.io/4d-seismic-hub/",
+    "repository_href: https://github.com/liuh886/4d-seismic-hub",
+  ],
+  "Selected deployments data",
+);
+
+const oceanHub = read("_projects/2026_oceanhub.md");
+requireIncludes(
+  oceanHub,
+  [
+    "https://liuh886.github.io/oceanhub/",
+    "https://github.com/liuh886/OceanHub",
+    "Open OceanHub",
+    "View Source Code",
+  ],
+  "OceanHub project record",
+);
+
+if (failures.length > 0) {
+  console.error("Homepage content contract check failed:");
+  failures.forEach((message) => console.error(`- ${message}`));
+  process.exit(1);
+}
+
+console.log("Homepage content contract check passed.");

--- a/test/home_content_contract.js
+++ b/test/home_content_contract.js
@@ -25,14 +25,15 @@ const about = read("_pages/about.md");
 requireIncludes(
   about,
   [
-    "Six maintained product and research lanes.",
+    "Five maintained product and research lanes.",
+    "site.data.current_operations.upcoming",
     "operation.secondary_href",
     "deployment.repository_href",
     "deployment.href contains 'http'",
   ],
   "Homepage content template",
 );
-requireAbsent(about, ["Five maintained product and research lanes."], "Homepage content template");
+requireAbsent(about, ["Six maintained product and research lanes."], "Homepage content template");
 
 const operations = read("_data/current_operations.yml");
 requireIncludes(
@@ -41,6 +42,7 @@ requireIncludes(
     "title: AlphaEngine",
     "href: https://liuh886.github.io/alpha_engine/",
     "secondary_href: https://github.com/liuh886/alpha_engine",
+    "upcoming:",
     "title: NewsFlow",
     "status: COMING SOON",
     "href: https://github.com/liuh886/NewsFlow",
@@ -49,7 +51,10 @@ requireIncludes(
 );
 requireAbsent(
   operations,
-  ["href: https://github.com/liuh886/alpha_engine\n    label: View repository"],
+  [
+    "href: https://github.com/liuh886/alpha_engine\n    label: View repository",
+    "- id: OP-06",
+  ],
   "Current operations data",
 );
 


### PR DESCRIPTION
## Summary

- change AlphaEngine from a repository-only card to a live `Open app` entry, while retaining a repository link
- promote OceanHub and 4D Seismic Hub to their deployed apps from the homepage project cards
- preserve the internal project records and repository links as secondary actions
- add OceanHub app and source buttons to its detailed project page
- add NewsFlow as a restrained `COMING SOON` card linked to its public repository
- keep the headline at five maintained lanes because NewsFlow is not yet counted as a maintained product

## Link model

- **AlphaEngine:** Open app + Repository
- **OceanHub:** Open app + Project record + Repository
- **4D Seismic Hub:** Open app + Project record + Repository
- **NewsFlow:** Follow build until a public app is available

## Validation

- add a homepage content contract covering the live app URLs, NewsFlow status, and multi-link rendering
- distinguish maintained work from upcoming work in the data model
- keep existing layout, atmosphere, portfolio, repositories, and production-build checks unchanged