### PR TITLE
content: open the live NewsFlow app

### DIFF
--- a/_data/current_operations.yml
+++ b/_data/current_operations.yml
@@ -35,10 +35,12 @@ operations:
 upcoming:
   - id: NEXT-01
     title: NewsFlow
-    status: COMING SOON
-    summary: An upcoming product now entering active build. The repository is public; the app link and fuller product record will be added after the first usable release is ready.
-    href: https://github.com/liuh886/NewsFlow
-    label: Follow build
+    status: LIVE APP
+    summary: A newly launched topic-intelligence publication that uses an editor-led, automated workflow to collect, filter, and organize high-quality information into recurring editions.
+    href: https://liuh886.github.io/NewsFlow/
+    label: Open app
+    secondary_href: https://github.com/liuh886/NewsFlow
+    secondary_label: Repository
 
 dispatches:
   - date: 2026-08-02

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -53,7 +53,7 @@ home_cta: false
     <div class="hao-home-section-header">
       <p class="hao-home-eyebrow">Current work</p>
       <h2 id="current-work-title">Five maintained product and research lanes.</h2>
-      <p>Five active systems are maintained now; the final card shows the next product entering build. Archived projects and supporting tools appear separately below.</p>
+      <p>Five established systems are maintained here; the final card highlights NewsFlow, the newest live release. Archived projects and supporting tools appear separately below.</p>
     </div>
     <div class="hao-home-card-grid">
       {% for operation in site.data.current_operations.operations %}
@@ -82,9 +82,14 @@ home_cta: false
           </div>
           <h3>{{ upcoming.title }}</h3>
           <p>{{ upcoming.summary }}</p>
-          {% if upcoming.href %}
-            <a class="hao-home-text-link" href="{{ upcoming.href }}" target="_blank" rel="noopener noreferrer">{{ upcoming.label | default: "Follow build" }} →</a>
-          {% endif %}
+          <div class="hao-home-links">
+            {% if upcoming.href %}
+              <a class="hao-home-text-link" href="{{ upcoming.href }}" target="_blank" rel="noopener noreferrer">{{ upcoming.label | default: "Open" }} →</a>
+            {% endif %}
+            {% if upcoming.secondary_href %}
+              <a class="hao-home-text-link" href="{{ upcoming.secondary_href }}" target="_blank" rel="noopener noreferrer">{{ upcoming.secondary_label | default: "Repository" }} →</a>
+            {% endif %}
+          </div>
         </article>
       {% endfor %}
     </div>

--- a/test/home_content_contract.js
+++ b/test/home_content_contract.js
@@ -26,14 +26,16 @@ requireIncludes(
   about,
   [
     "Five maintained product and research lanes.",
+    "NewsFlow, the newest live release.",
     "site.data.current_operations.upcoming",
     "operation.secondary_href",
+    "upcoming.secondary_href",
     "deployment.repository_href",
     "deployment.href contains 'http'",
   ],
   "Homepage content template",
 );
-requireAbsent(about, ["Six maintained product and research lanes."], "Homepage content template");
+requireAbsent(about, ["the next product entering build", "Six maintained product and research lanes."], "Homepage content template");
 
 const operations = read("_data/current_operations.yml");
 requireIncludes(
@@ -44,8 +46,10 @@ requireIncludes(
     "secondary_href: https://github.com/liuh886/alpha_engine",
     "upcoming:",
     "title: NewsFlow",
-    "status: COMING SOON",
-    "href: https://github.com/liuh886/NewsFlow",
+    "status: LIVE APP",
+    "href: https://liuh886.github.io/NewsFlow/",
+    "label: Open app",
+    "secondary_href: https://github.com/liuh886/NewsFlow",
   ],
   "Current operations data",
 );
@@ -53,6 +57,8 @@ requireAbsent(
   operations,
   [
     "href: https://github.com/liuh886/alpha_engine\n    label: View repository",
+    "status: COMING SOON",
+    "label: Follow build",
     "- id: OP-06",
   ],
   "Current operations data",


### PR DESCRIPTION
## Summary
- change NewsFlow from `COMING SOON` to `LIVE APP`
- point the primary action to the deployed NewsFlow site with `Open app`
- retain the GitHub repository as a secondary action
- update the homepage copy and content contract so the card is described as the newest live release

## Scope
Homepage content and its existing contract only; no layout or visual-system changes.