### PR TITLE
fix: correct OceanHub Pages URL casing

### DIFF
--- a/_data/selected_deployments.yml
+++ b/_data/selected_deployments.yml
@@ -16,7 +16,7 @@ groups:
         status: PLATFORM
         kind: Offshore energy / marine intelligence
         summary: A partner-facing offshore energy and marine intelligence portal supported by a reproducible content and presentation pipeline.
-        href: https://liuh886.github.io/oceanhub/
+        href: https://liuh886.github.io/OceanHub/
         primary_label: Open app
         secondary_href: /projects/2026_oceanhub/
         secondary_label: Project record

--- a/_projects/2026_oceanhub.md
+++ b/_projects/2026_oceanhub.md
@@ -14,11 +14,11 @@ category: work
 > - **Method:** Astro + Tailwind site with typed content collections; automated partner deck generation from source content.
 > - **Output:** A live platform-style portal plus a reusable partner introduction deck pipeline.
 > - **Impact:** Faster alignment across ecosystem partners and a repeatable workflow to publish updates consistently.
-> - **Links:** [Open OceanHub](https://liuh886.github.io/oceanhub/) · [Source code](https://github.com/liuh886/OceanHub) · [SBGf Rio 25 reference](https://rio25.sbgf.org.br/Pages/oceanHub.php)
+> - **Links:** [Open OceanHub](https://liuh886.github.io/OceanHub/) · [Source code](https://github.com/liuh886/OceanHub) · [SBGf Rio 25 reference](https://rio25.sbgf.org.br/Pages/oceanHub.php)
 
 <div class="row mt-3">
     <div class="col-sm mt-3 mt-md-0">
-        <a href="https://liuh886.github.io/oceanhub/" target="_blank" class="btn btn-primary w-100">
+        <a href="https://liuh886.github.io/OceanHub/" target="_blank" class="btn btn-primary w-100">
             <i class="fa-solid fa-arrow-up-right-from-square"></i> Open OceanHub
         </a>
     </div>

--- a/test/home_content_contract.js
+++ b/test/home_content_contract.js
@@ -69,7 +69,7 @@ requireIncludes(
   deployments,
   [
     "title: OceanHub",
-    "href: https://liuh886.github.io/oceanhub/",
+    "href: https://liuh886.github.io/OceanHub/",
     "repository_href: https://github.com/liuh886/OceanHub",
     "title: 4D Seismic Hub",
     "href: https://liuh886.github.io/4d-seismic-hub/",
@@ -77,18 +77,20 @@ requireIncludes(
   ],
   "Selected deployments data",
 );
+requireAbsent(deployments, ["https://liuh886.github.io/oceanhub/"], "Selected deployments data");
 
 const oceanHub = read("_projects/2026_oceanhub.md");
 requireIncludes(
   oceanHub,
   [
-    "https://liuh886.github.io/oceanhub/",
+    "https://liuh886.github.io/OceanHub/",
     "https://github.com/liuh886/OceanHub",
     "Open OceanHub",
     "View Source Code",
   ],
   "OceanHub project record",
 );
+requireAbsent(oceanHub, ["https://liuh886.github.io/oceanhub/"], "OceanHub project record");
 
 if (failures.length > 0) {
   console.error("Homepage content contract check failed:");


### PR DESCRIPTION
## Summary
- update OceanHub links from `https://liuh886.github.io/oceanhub/` to `https://liuh886.github.io/OceanHub/`
- correct both the homepage project card and OceanHub project record
- update the homepage content contract to require the case-sensitive URL and reject the obsolete lowercase path

## Scope
URL correction only; no content, layout, or visual changes.