### PR TITLE
observability: add Cloudflare RUM to Notes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,7 @@ jobs:
           npm run lint:style-contract
           npx prettier --check test/style_contract.js
           ruby -c _plugins/site_visual_polish.rb
+          ruby -c _plugins/cloudflare_web_analytics.rb
 
       - name: Install responsive-image runtime
         if: steps.impact.outputs.responsive_images == 'true'
@@ -87,6 +88,7 @@ jobs:
       - name: Build production site 🔧
         env:
           RESPONSIVE_IMAGES: ${{ steps.impact.outputs.responsive_images }}
+          CLOUDFLARE_WEB_ANALYTICS_TOKEN: ${{ vars.CLOUDFLARE_WEB_ANALYTICS_TOKEN || '' }}
         run: |
           set -euo pipefail
           export JEKYLL_ENV=production
@@ -102,6 +104,16 @@ jobs:
           if grep -q 'Conflict: The following destination is shared by multiple files' .build-jekyll.log; then
             echo 'Jekyll emitted an ambiguous destination conflict.' >&2
             exit 1
+          fi
+
+      - name: Verify Cloudflare RUM artifact 🔎
+        env:
+          CLOUDFLARE_WEB_ANALYTICS_TOKEN: ${{ vars.CLOUDFLARE_WEB_ANALYTICS_TOKEN || '' }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$CLOUDFLARE_WEB_ANALYTICS_TOKEN" ]]; then
+            grep -q 'static.cloudflareinsights.com/beacon.min.js' _site/index.html
+            grep -q "$CLOUDFLARE_WEB_ANALYTICS_TOKEN" _site/index.html
           fi
 
       - name: Verify built homepage artifact 🔎

--- a/_plugins/cloudflare_web_analytics.rb
+++ b/_plugins/cloudflare_web_analytics.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "json"
+
+module CloudflareWebAnalytics
+  BEACON_SRC = "https://static.cloudflareinsights.com/beacon.min.js".freeze
+
+  def self.inject(page)
+    token = ENV.fetch("CLOUDFLARE_WEB_ANALYTICS_TOKEN", "").strip
+    return if token.empty?
+    return unless page.output.include?("</head>")
+    return if page.output.include?(BEACON_SRC)
+
+    config = JSON.generate(token: token)
+    tag = %(<script type="module" src="#{BEACON_SRC}" data-cf-beacon='#{config}'></script>)
+    page.output = page.output.sub("</head>", "#{tag}</head>")
+  end
+end
+
+[:pages, :documents].each do |hook_owner|
+  Jekyll::Hooks.register hook_owner, :post_render do |page|
+    CloudflareWebAnalytics.inject(page)
+  end
+end


### PR DESCRIPTION
## Summary
- keep the existing GA4/Search Console path for acquisition and content behavior;
- add Cloudflare Web Analytics as the privacy-first RUM/performance layer for the Notes custom hostname;
- inject the beacon from `CLOUDFLARE_WEB_ANALYTICS_TOKEN` during the existing Jekyll build;
- verify the plugin syntax and emitted production artifact when the repository variable is configured.

## Architecture
Notes remains on `zhihaol.eu.org`, so it must use its own Cloudflare Web Analytics Site rather than the shared `liuh886.github.io` Site. No membership or Stripe integration is added.

## External activation
After creating the `zhihaol.eu.org` Web Analytics Site in Cloudflare, set its public Site Token as the repository variable `CLOUDFLARE_WEB_ANALYTICS_TOKEN`.