### PR TITLE
observability: enable Cloudflare Web Analytics on zhihaol.eu.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,6 @@ jobs:
       - name: Build production site 🔧
         env:
           RESPONSIVE_IMAGES: ${{ steps.impact.outputs.responsive_images }}
-          CLOUDFLARE_WEB_ANALYTICS_TOKEN: ${{ vars.CLOUDFLARE_WEB_ANALYTICS_TOKEN || '' }}
         run: |
           set -euo pipefail
           export JEKYLL_ENV=production
@@ -107,14 +106,10 @@ jobs:
           fi
 
       - name: Verify Cloudflare RUM artifact 🔎
-        env:
-          CLOUDFLARE_WEB_ANALYTICS_TOKEN: ${{ vars.CLOUDFLARE_WEB_ANALYTICS_TOKEN || '' }}
         run: |
           set -euo pipefail
-          if [[ -n "$CLOUDFLARE_WEB_ANALYTICS_TOKEN" ]]; then
-            grep -q 'static.cloudflareinsights.com/beacon.min.js' _site/index.html
-            grep -q "$CLOUDFLARE_WEB_ANALYTICS_TOKEN" _site/index.html
-          fi
+          grep -q 'static.cloudflareinsights.com/beacon.min.js' _site/index.html
+          grep -q 'b047ab48e64f47a49ae504d0e92c43e2' _site/index.html
 
       - name: Verify built homepage artifact 🔎
         run: |

--- a/_plugins/cloudflare_web_analytics.rb
+++ b/_plugins/cloudflare_web_analytics.rb
@@ -4,14 +4,13 @@ require "json"
 
 module CloudflareWebAnalytics
   BEACON_SRC = "https://static.cloudflareinsights.com/beacon.min.js".freeze
+  TOKEN = "b047ab48e64f47a49ae504d0e92c43e2".freeze
 
   def self.inject(page)
-    token = ENV.fetch("CLOUDFLARE_WEB_ANALYTICS_TOKEN", "").strip
-    return if token.empty?
     return unless page.output.include?("</head>")
     return if page.output.include?(BEACON_SRC)
 
-    config = JSON.generate(token: token)
+    config = JSON.generate(token: TOKEN)
     tag = %(<script type="module" src="#{BEACON_SRC}" data-cf-beacon='#{config}'></script>)
     page.output = page.output.sub("</head>", "#{tag}</head>")
   end

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "lint:prettier": "prettier . --check",
-    "lint:style-contract": "node test/style_contract.js && node test/repositories_contract.js && node test/portfolio_contract.js && node test/home_atmosphere_contract.js && node test/home_content_contract.js && node test/project_shortlinks_contract.js",
+    "lint:style-contract": "node test/style_contract.js && node test/repositories_contract.js && node test/portfolio_contract.js && node test/home_atmosphere_contract.js && node test/home_content_contract.js && node test/project_shortlinks_contract.js && node test/cloudflare_analytics_contract.js",
     "test:visual": "playwright test --config test/visual/playwright.config.js",
     "test:visual:update": "playwright test --config test/visual/playwright.config.js --update-snapshots"
   },

--- a/test/cloudflare_analytics_contract.js
+++ b/test/cloudflare_analytics_contract.js
@@ -1,0 +1,20 @@
+const fs = require('node:fs');
+
+const plugin = fs.readFileSync('_plugins/cloudflare_web_analytics.rb', 'utf8');
+const token = 'b047ab48e64f47a49ae504d0e92c43e2';
+const beacon = 'https://static.cloudflareinsights.com/beacon.min.js';
+
+if (!plugin.includes(`TOKEN = "${token}".freeze`)) {
+  throw new Error('Cloudflare Web Analytics token is not pinned for zhihaol.eu.org.');
+}
+if (!plugin.includes(beacon)) {
+  throw new Error('Cloudflare Web Analytics beacon is missing.');
+}
+if (!plugin.includes('data-cf-beacon')) {
+  throw new Error('Cloudflare Web Analytics data-cf-beacon attribute is missing.');
+}
+if (plugin.includes('CLOUDFLARE_WEB_ANALYTICS_TOKEN') || plugin.includes('ENV.fetch')) {
+  throw new Error('Notes analytics must not retain the retired environment-token configuration layer.');
+}
+
+console.log('Cloudflare Web Analytics is pinned for zhihaol.eu.org.');


### PR DESCRIPTION
## Goal
Enable Cloudflare Web Analytics for the Notes site at `https://zhihaol.eu.org` using the dedicated public token provided for this hostname.

## Implementation
- Reuse the existing Jekyll post-render injector so the beacon is inserted into every rendered page before `</head>`.
- Pin the public Notes token directly in the plugin; remove the retired environment-token configuration layer.
- Add a source contract to prevent token/beacon drift and prevent the old env-token path from returning.
- Make CI verify the generated homepage contains both the Cloudflare beacon and the exact Notes token.

## Scope
No GA4 behavior is changed in this PR. No new dependency, layout override, backend, migration, or compatibility layer is added.