### PR TITLE
observability: use Cloudflare analytics repository variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,8 +88,13 @@ jobs:
       - name: Build production site 🔧
         env:
           RESPONSIVE_IMAGES: ${{ steps.impact.outputs.responsive_images }}
+          CLOUDFLARE_WEB_ANALYTICS_TOKEN: ${{ vars.CLOUDFLARE_WEB_ANALYTICS_TOKEN }}
         run: |
           set -euo pipefail
+          if [[ -z "$CLOUDFLARE_WEB_ANALYTICS_TOKEN" ]]; then
+            echo 'CLOUDFLARE_WEB_ANALYTICS_TOKEN repository variable is required.' >&2
+            exit 1
+          fi
           export JEKYLL_ENV=production
           config_args=(--config _config.yml)
           if [[ "$RESPONSIVE_IMAGES" != "true" ]]; then
@@ -106,10 +111,13 @@ jobs:
           fi
 
       - name: Verify Cloudflare RUM artifact 🔎
+        env:
+          CLOUDFLARE_WEB_ANALYTICS_TOKEN: ${{ vars.CLOUDFLARE_WEB_ANALYTICS_TOKEN }}
         run: |
           set -euo pipefail
+          test -n "$CLOUDFLARE_WEB_ANALYTICS_TOKEN"
           grep -q 'static.cloudflareinsights.com/beacon.min.js' _site/index.html
-          grep -q 'b047ab48e64f47a49ae504d0e92c43e2' _site/index.html
+          grep -q "$CLOUDFLARE_WEB_ANALYTICS_TOKEN" _site/index.html
 
       - name: Verify built homepage artifact 🔎
         run: |

--- a/_plugins/cloudflare_web_analytics.rb
+++ b/_plugins/cloudflare_web_analytics.rb
@@ -4,13 +4,14 @@ require "json"
 
 module CloudflareWebAnalytics
   BEACON_SRC = "https://static.cloudflareinsights.com/beacon.min.js".freeze
-  TOKEN = "b047ab48e64f47a49ae504d0e92c43e2".freeze
 
   def self.inject(page)
+    token = ENV.fetch("CLOUDFLARE_WEB_ANALYTICS_TOKEN", "").strip
+    return if token.empty?
     return unless page.output.include?("</head>")
     return if page.output.include?(BEACON_SRC)
 
-    config = JSON.generate(token: TOKEN)
+    config = JSON.generate(token: token)
     tag = %(<script type="module" src="#{BEACON_SRC}" data-cf-beacon='#{config}'></script>)
     page.output = page.output.sub("</head>", "#{tag}</head>")
   end

--- a/test/cloudflare_analytics_contract.js
+++ b/test/cloudflare_analytics_contract.js
@@ -1,11 +1,10 @@
 const fs = require('node:fs');
 
 const plugin = fs.readFileSync('_plugins/cloudflare_web_analytics.rb', 'utf8');
-const token = 'b047ab48e64f47a49ae504d0e92c43e2';
 const beacon = 'https://static.cloudflareinsights.com/beacon.min.js';
 
-if (!plugin.includes(`TOKEN = "${token}".freeze`)) {
-  throw new Error('Cloudflare Web Analytics token is not pinned for zhihaol.eu.org.');
+if (!plugin.includes('ENV.fetch("CLOUDFLARE_WEB_ANALYTICS_TOKEN", "").strip')) {
+  throw new Error('Notes analytics must read CLOUDFLARE_WEB_ANALYTICS_TOKEN from the build environment.');
 }
 if (!plugin.includes(beacon)) {
   throw new Error('Cloudflare Web Analytics beacon is missing.');
@@ -13,8 +12,8 @@ if (!plugin.includes(beacon)) {
 if (!plugin.includes('data-cf-beacon')) {
   throw new Error('Cloudflare Web Analytics data-cf-beacon attribute is missing.');
 }
-if (plugin.includes('CLOUDFLARE_WEB_ANALYTICS_TOKEN') || plugin.includes('ENV.fetch')) {
-  throw new Error('Notes analytics must not retain the retired environment-token configuration layer.');
+if (/TOKEN\s*=\s*"[a-f0-9]{32}"/.test(plugin)) {
+  throw new Error('Notes analytics must not hardcode the Cloudflare token.');
 }
 
-console.log('Cloudflare Web Analytics is pinned for zhihaol.eu.org.');
+console.log('Cloudflare Web Analytics uses the repository-variable build path.');


### PR DESCRIPTION
## Goal
Use the repository-level `CLOUDFLARE_WEB_ANALYTICS_TOKEN` as the single source of truth for Notes Cloudflare Web Analytics.

## Changes
- Remove the hardcoded Notes analytics token from the Jekyll plugin.
- Read `CLOUDFLARE_WEB_ANALYTICS_TOKEN` from the build environment.
- Pass the repository Variable into the production Jekyll build.
- Fail CI if the Variable is missing.
- Verify the generated `_site/index.html` contains both the Cloudflare beacon and the configured Variable value.
- Update the source contract so hardcoded 32-hex token constants are rejected.

No fallback or duplicate configuration path is retained.