### PR TITLE
proposal: curate homepage instead of expanding the directory

### DIFF
--- a/docs/HOMEPAGE_CURATION_PROPOSAL_2026_08.md
+++ b/docs/HOMEPAGE_CURATION_PROPOSAL_2026_08.md
@@ -1,0 +1,78 @@
+# Homepage curation proposal — August 2026
+
+Status: **proposal only — no public homepage changes in this PR**.
+
+## Goal
+
+Keep the homepage as a strong personal entry point rather than allowing it to become an exhaustive directory as more products and research outputs accumulate.
+
+The proposed principle is simple:
+
+> The homepage should explain who Zhihao is, what he builds, and which few pieces of work best prove it. Complete archives should remain one click deeper.
+
+## Proposed reading order
+
+### 1. Identity
+
+Keep the current identity statement and short description concise. This section should answer:
+
+- who you are;
+- the domains you work across;
+- the kind of systems/research you build.
+
+No proposal here requires changing the current professional positioning before explicit review.
+
+### 2. Current thesis / active work
+
+Retain a compact current-work section, but avoid automatically giving every maintained repository equal homepage weight forever.
+
+As the active portfolio grows, select the systems that best represent the current direction and route the rest to the project/repository archive.
+
+### 3. Selected systems
+
+A future implementation could feature roughly three high-signal systems rather than treating the homepage as the canonical list of all live products. Selection criteria should be explicit, for example:
+
+- strongest product maturity;
+- strongest evidence of technical depth;
+- strongest connection to climate/energy/geoscience/AI identity;
+- strongest current public relevance.
+
+No specific project is proposed for removal in this Draft PR.
+
+### 4. Research and writing
+
+Keep formal outputs and selected notes visibly distinct. The homepage should surface a small, curated sample and link to the full publication and notes archives.
+
+### 5. Full record
+
+Projects, repositories, publications, CV, and notes archives remain the durable complete record. The homepage should route to them rather than duplicate all of them.
+
+## Content that should remain available
+
+- all current projects and repositories;
+- publications and datasets;
+- field/research notes;
+- CV and career record;
+- contact routes;
+- existing archive pages.
+
+This proposal changes hierarchy, not ownership or availability of content.
+
+## Explicit non-goals
+
+- no public copy change in this PR;
+- no project removal;
+- no CV change;
+- no publication/archive deletion;
+- no visual redesign;
+- no framework/theme change;
+- no implementation until the selection/hierarchy is explicitly approved.
+
+## Review gate
+
+A later implementation PR should be created only after approval of:
+
+1. whether the homepage should become more curated;
+2. how many active systems deserve first-page prominence;
+3. which systems are selected;
+4. whether the current identity copy should remain exactly as-is.


### PR DESCRIPTION
## Proposal only
This Draft PR changes **no public homepage, copy, project list, styling, or archive content**. It adds a review document for a future curation decision: keep the homepage focused on identity + a small number of selected systems, while complete records remain in archives.

No implementation should happen until the selection criteria and any affected projects are explicitly approved.