### PR TITLE
feat: add shortlinks for product sites

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://liuh886.github.io/admin/">
+  <link rel="canonical" href="https://liuh886.github.io/admin/">
+  <title>Admin</title>
+</head>
+<body>
+  <p><a href="https://liuh886.github.io/admin/">Open Admin</a></p>
+</body>
+</html>

--- a/alpha_engine/index.html
+++ b/alpha_engine/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://liuh886.github.io/alpha_engine/">
+  <link rel="canonical" href="https://liuh886.github.io/alpha_engine/">
+  <title>Alpha Engine</title>
+</head>
+<body>
+  <p><a href="https://liuh886.github.io/alpha_engine/">Open Alpha Engine</a></p>
+</body>
+</html>

--- a/flappyk/index.html
+++ b/flappyk/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://liuh886.github.io/FlappyK/">
+  <link rel="canonical" href="https://liuh886.github.io/FlappyK/">
+  <title>FlappyK</title>
+</head>
+<body>
+  <p><a href="https://liuh886.github.io/FlappyK/">Open FlappyK</a></p>
+</body>
+</html>

--- a/newsflow/index.html
+++ b/newsflow/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://liuh886.github.io/NewsFlow/">
+  <link rel="canonical" href="https://liuh886.github.io/NewsFlow/">
+  <title>NewsFlow</title>
+</head>
+<body>
+  <p><a href="https://liuh886.github.io/NewsFlow/">Open NewsFlow</a></p>
+</body>
+</html>

--- a/ownly/index.html
+++ b/ownly/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://liuh886.github.io/ownly/">
+  <link rel="canonical" href="https://liuh886.github.io/ownly/">
+  <title>Ownly</title>
+</head>
+<body>
+  <p><a href="https://liuh886.github.io/ownly/">Open Ownly</a></p>
+</body>
+</html>

--- a/rhythmcoach/index.html
+++ b/rhythmcoach/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://liuh886.github.io/RhythmCoach/">
+  <link rel="canonical" href="https://liuh886.github.io/RhythmCoach/">
+  <title>RhythmCoach</title>
+</head>
+<body>
+  <p><a href="https://liuh886.github.io/RhythmCoach/">Open RhythmCoach</a></p>
+</body>
+</html>


### PR DESCRIPTION
Add lightweight redirect entrypoints on zhihaol.eu.org for the current product sites without changing any product deployment, auth, PWA, or domain configuration.

Shortlinks:
- /alpha_engine → Alpha Engine
- /newsflow → NewsFlow
- /ownly → Ownly
- /rhythmcoach → RhythmCoach
- /flappyk → FlappyK
- /admin → Admin

Implementation is static HTML only: no new dependencies or routing layer.