### PR TITLE
seo: make Google site name explicit on homepage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,7 @@ jobs:
           npx prettier --check test/style_contract.js
           ruby -c _plugins/site_visual_polish.rb
           ruby -c _plugins/cloudflare_web_analytics.rb
+          ruby -c _plugins/site_name_metadata.rb
 
       - name: Install responsive-image runtime
         if: steps.impact.outputs.responsive_images == 'true'
@@ -130,6 +131,10 @@ jobs:
           grep -q 'id="selected-work"' _site/index.html
           grep -q 'id="notes-publications"' _site/index.html
           grep -q 'id="contact"' _site/index.html
+          grep -Fq '"@type":"WebSite"' _site/index.html
+          grep -Fq '"name":"Zhihao LIU"' _site/index.html
+          grep -Fq '"alternateName":"zhihaol.eu.org"' _site/index.html
+          grep -Fq '"url":"https://zhihaol.eu.org/"' _site/index.html
           if grep -q 'mission-log-shell-v2.css' _site/index.html; then
             echo "Deprecated Mission Log stylesheet leaked into homepage artifact."
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,7 +135,7 @@ jobs:
           require "json"
 
           html = File.read("_site/index.html")
-          nodes = html.scan(%r{<script[^>]*type=["']application/ld\+json["'][^>]*>(.*?)</script>}m).filter_map do |match|
+          nodes = html.scan(%r{<script\b[^>]*\btype=(?:["']application/ld\+json["']|application/ld\+json)[^>]*>(.*?)</script>}m).filter_map do |match|
             JSON.parse(match.first)
           rescue JSON::ParserError
             nil

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Classify responsive-image impact
         id: impact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,10 +131,28 @@ jobs:
           grep -q 'id="selected-work"' _site/index.html
           grep -q 'id="notes-publications"' _site/index.html
           grep -q 'id="contact"' _site/index.html
-          grep -Fq '"@type":"WebSite"' _site/index.html
-          grep -Fq '"name":"Zhihao LIU"' _site/index.html
-          grep -Fq '"alternateName":"zhihaol.eu.org"' _site/index.html
-          grep -Fq '"url":"https://zhihaol.eu.org/"' _site/index.html
+          ruby <<'RUBY'
+          require "json"
+
+          html = File.read("_site/index.html")
+          nodes = html.scan(%r{<script[^>]*type=["']application/ld\+json["'][^>]*>(.*?)</script>}m).filter_map do |match|
+            JSON.parse(match.first)
+          rescue JSON::ParserError
+            nil
+          end
+          websites = nodes.select { |node| node["@type"] == "WebSite" }
+          abort "Expected exactly one WebSite JSON-LD node, found #{websites.length}." unless websites.length == 1
+
+          expected = {
+            "name" => "Zhihao LIU",
+            "alternateName" => "zhihaol.eu.org",
+            "url" => "https://zhihaol.eu.org/"
+          }
+          expected.each do |key, value|
+            actual = websites.first[key]
+            abort "WebSite #{key} mismatch: expected #{value.inspect}, got #{actual.inspect}." unless actual == value
+          end
+          RUBY
           if grep -q 'mission-log-shell-v2.css' _site/index.html; then
             echo "Deprecated Mission Log stylesheet leaked into homepage artifact."
             exit 1

--- a/_plugins/site_name_metadata.rb
+++ b/_plugins/site_name_metadata.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "json"
+require "uri"
+
+module SiteNameMetadata
+  JSON_LD_SCRIPT = %r{<script\s+type=["']application/ld\+json["']>\s*(\{.*?\})\s*</script>}m
+
+  def self.rewrite(page)
+    return unless page.url == "/"
+    return unless page.output.include?("application/ld+json")
+
+    site_url = page.site.config.fetch("url", "").to_s.strip
+    site_name = page.site.config.fetch("title", "").to_s.strip
+    return if site_url.empty? || site_name.empty?
+
+    host = URI.parse(site_url).host&.downcase
+    return if host.nil? || host.empty?
+
+    page.output = page.output.sub(JSON_LD_SCRIPT) do |script|
+      data = JSON.parse(Regexp.last_match(1))
+      next script unless data["@type"] == "WebSite"
+
+      data["name"] = site_name
+      data["alternateName"] = host
+      data["url"] = "#{site_url.sub(%r{/+\z}, "")}/"
+
+      %(<script type="application/ld+json">#{JSON.generate(data)}</script>)
+    rescue JSON::ParserError
+      script
+    end
+  end
+end
+
+Jekyll::Hooks.register :pages, :post_render do |page|
+  SiteNameMetadata.rewrite(page)
+end

--- a/_plugins/site_name_metadata.rb
+++ b/_plugins/site_name_metadata.rb
@@ -4,34 +4,29 @@ require "json"
 require "uri"
 
 module SiteNameMetadata
-  JSON_LD_SCRIPT = %r{<script\b[^>]*\btype=(?:["']application/ld\+json["']|application/ld\+json)[^>]*>\s*(.*?)\s*</script>}m
-
-  def self.rewrite(page)
+  def self.inject(page)
     return unless page.url == "/"
-    return unless page.output.include?("application/ld+json")
 
-    site_url = page.site.config.fetch("url", "").to_s.strip
-    site_name = page.site.config.fetch("title", "").to_s.strip
-    return if site_url.empty? || site_name.empty?
+    site_url = page.site.config.fetch("url").to_s.sub(%r{/+\z}, "")
+    site_name = page.site.config.fetch("title").to_s
+    host = URI.parse(site_url).host
+    raise "Invalid site.url for WebSite metadata: #{site_url}" if host.nil? || host.empty?
 
-    host = URI.parse(site_url).host&.downcase
-    return if host.nil? || host.empty?
+    website = {
+      "@context" => "https://schema.org",
+      "@type" => "WebSite",
+      "name" => site_name,
+      "alternateName" => host.downcase,
+      "url" => "#{site_url}/"
+    }
+    script = %(<script type="application/ld+json">#{JSON.generate(website)}</script>)
 
-    page.output = page.output.gsub(JSON_LD_SCRIPT) do |script|
-      data = JSON.parse(Regexp.last_match(1))
-      next script unless data["@type"] == "WebSite"
+    raise "Homepage output has no </head> for WebSite metadata injection" unless page.output.include?("</head>")
 
-      data["name"] = site_name
-      data["alternateName"] = host
-      data["url"] = "#{site_url.sub(%r{/+\z}, "")}/"
-
-      %(<script type="application/ld+json">#{JSON.generate(data)}</script>)
-    rescue JSON::ParserError
-      script
-    end
+    page.output = page.output.sub("</head>", "#{script}</head>")
   end
 end
 
 Jekyll::Hooks.register :pages, :post_render do |page|
-  SiteNameMetadata.rewrite(page)
+  SiteNameMetadata.inject(page)
 end

--- a/_plugins/site_name_metadata.rb
+++ b/_plugins/site_name_metadata.rb
@@ -4,7 +4,7 @@ require "json"
 require "uri"
 
 module SiteNameMetadata
-  JSON_LD_SCRIPT = %r{<script\s+type=["']application/ld\+json["']>\s*(\{.*?\})\s*</script>}m
+  JSON_LD_SCRIPT = %r{<script\s+type=["']application/ld\+json["']>\s*(.*?)\s*</script>}m
 
   def self.rewrite(page)
     return unless page.url == "/"

--- a/_plugins/site_name_metadata.rb
+++ b/_plugins/site_name_metadata.rb
@@ -4,7 +4,7 @@ require "json"
 require "uri"
 
 module SiteNameMetadata
-  JSON_LD_SCRIPT = %r{<script\s+type=["']application/ld\+json["']>\s*(.*?)\s*</script>}m
+  JSON_LD_SCRIPT = %r{<script\b[^>]*\btype=(?:["']application/ld\+json["']|application/ld\+json)[^>]*>\s*(.*?)\s*</script>}m
 
   def self.rewrite(page)
     return unless page.url == "/"

--- a/_plugins/site_name_metadata.rb
+++ b/_plugins/site_name_metadata.rb
@@ -17,7 +17,7 @@ module SiteNameMetadata
     host = URI.parse(site_url).host&.downcase
     return if host.nil? || host.empty?
 
-    page.output = page.output.sub(JSON_LD_SCRIPT) do |script|
+    page.output = page.output.gsub(JSON_LD_SCRIPT) do |script|
       data = JSON.parse(Regexp.last_match(1))
       next script unless data["@type"] == "WebSite"
 


### PR DESCRIPTION
## Problem
Google is showing the parent-domain label `EU.org: free domain names since 1996` above Notes search results for `zhihaol.eu.org`.

## Diagnosis
The proposed direction is correct, but the repo is Jekyll/al-folio rather than Quarto. The configured theme source has Schema.org support, yet the actual production Jekyll build contained **zero parseable `WebSite` JSON-LD nodes** on the homepage. That production-artifact gap is what matters to Google.

Google supports site names at the subdomain level and recommends `WebSite` structured data on the homepage, with `alternateName` as a fallback candidate. For this site the canonical preference is:

- `name = Zhihao LIU`
- `alternateName = zhihaol.eu.org`
- `url = https://zhihaol.eu.org/`

## Change
- inject one canonical `WebSite` JSON-LD node into the rendered homepage `<head>` using a small Jekyll post-render plugin
- derive the name and URL from the existing site config; no new dependency or extra config layer
- fail loudly if the homepage has no `<head>` or the configured URL is invalid
- validate the **final built `_site/index.html`** and require exactly one parseable `WebSite` node with the expected values
- keep the deploy workflow lightweight by using the shallow history actually needed by the PR diff check

## Why this shape
We do not shadow/copy the theme's large metadata include and we do not add a compatibility/fallback layer. The build contract is explicit: the final artifact must contain exactly one canonical `WebSite` node. If the theme changes later and starts emitting another one, CI will fail instead of silently producing conflicting metadata.

## Validation
Both PR workflows pass on the final head:
- `deploy` ✅ — production Jekyll build + homepage structured-data artifact assertion
- `CI Governance` ✅

After merge/deploy, the remaining external step is Google Search Console → URL Inspection for the homepage → Request indexing. Site-name changes depend on Google recrawling/reprocessing and can take days to weeks. Note that Google's current documentation says the Rich Results Test does **not** support site names; Schema Markup Validator/URL Inspection are the appropriate checks.