### PR TITLE
Restore native Blog layout and remove lane model

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -12,146 +12,97 @@ pagination:
   sort_field: date
   sort_reverse: true
   trail:
-    before: 1
-    after: 3
+    before: 1 # The number of links before the current page
+    after: 3 # The number of links after the current page
 ---
 
-<div class="post hao-blog-index">
+<div class="post">
+
+{% assign blog_name_size = site.blog_name | size %}
+{% assign blog_description_size = site.blog_description | size %}
+
+{% if blog_name_size > 0 or blog_description_size > 0 %}
+
   <div class="header-bar">
-    <h1>Hao's Notes</h1>
-    <h2>Research notes on climate, geospatial data, AI systems, and things I build.</h2>
-    <p class="post-meta">Mens sana in corpore sano.</p>
+    <h1>{{ site.blog_name }}</h1>
+    <h2>{{ site.blog_description }}</h2>
   </div>
+  {% endif %}
 
-  <nav class="tag-category-list" aria-label="Editorial lanes">
+{% if site.display_tags and site.display_tags.size > 0 or site.display_categories and site.display_categories.size > 0 %}
+
+  <div class="tag-category-list">
     <ul class="p-0 m-0">
-      <li><a href="#research-notes">Research Notes</a></li>
-      <p>&bull;</p>
-      <li><a href="#build-logs">Build Logs</a></li>
-      <p>&bull;</p>
-      <li><a href="#field-notes">Field Notes</a></li>
-      <p>&bull;</p>
-      <li><a href="#essays">Essays</a></li>
-    </ul>
-  </nav>
-
-  {% assign research_posts = site.posts | where: "lane", "research" %}
-  <section id="research-notes" aria-labelledby="research-notes-title">
-    <h2 id="research-notes-title">Research Notes</h2>
-    <p>Methods, datasets, papers, and technical reasoning from climate, remote sensing, geospatial analysis, and geoscience.</p>
-    <ul class="post-list">
-      {% for post in research_posts %}
+      {% for tag in site.display_tags %}
         <li>
-          <h3>
-            {% if post.redirect == blank %}
-              <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-            {% elsif post.redirect contains '://' %}
-              <a class="post-title" href="{{ post.redirect }}" target="_blank" rel="noopener noreferrer">{{ post.title }}</a>
-            {% else %}
-              <a class="post-title" href="{{ post.redirect | relative_url }}">{{ post.title }}</a>
-            {% endif %}
-          </h3>
-          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
-          <p class="post-meta">{{ post.date | date: '%B %d, %Y' }}</p>
+          <i class="fa-solid fa-hashtag fa-sm"></i> <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">{{ tag }}</a>
         </li>
+        {% unless forloop.last %}
+          <p>&bull;</p>
+        {% endunless %}
+      {% endfor %}
+      {% if site.display_categories.size > 0 and site.display_tags.size > 0 %}
+        <p>&bull;</p>
+      {% endif %}
+      {% for category in site.display_categories %}
+        <li>
+          <i class="fa-solid fa-tag fa-sm"></i> <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">{{ category }}</a>
+        </li>
+        {% unless forloop.last %}
+          <p>&bull;</p>
+        {% endunless %}
       {% endfor %}
     </ul>
-  </section>
+  </div>
+  {% endif %}
 
-  {% assign build_posts = site.posts | where: "lane", "build" %}
-  <section id="build-logs" aria-labelledby="build-logs-title">
-    <h2 id="build-logs-title">Build Logs</h2>
-    <p>Architecture decisions, agentic workflows, personal software, and lessons from turning ideas into working systems.</p>
-    <ul class="post-list">
-      {% for post in build_posts %}
-        <li>
-          <h3><a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
-          <p class="post-meta">{{ post.date | date: '%B %d, %Y' }}</p>
-        </li>
-      {% endfor %}
-    </ul>
-  </section>
+{% assign featured_posts = site.posts | where: "featured", "true" %}
+{% if featured_posts.size > 0 %}
+<br>
 
-  {% assign field_posts = site.posts | where: "lane", "field" %}
-  <section id="field-notes" aria-labelledby="field-notes-title">
-    <h2 id="field-notes-title">Field Notes</h2>
-    <p>Observations from field work, expeditions, travel, and direct encounters with landscapes, instruments, and operational problems.</p>
-    <ul class="post-list">
-      {% for post in field_posts %}
-        <li>
-          <h3>
-            {% if post.redirect == blank %}
-              <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-            {% elsif post.redirect contains '://' %}
-              <a class="post-title" href="{{ post.redirect }}" target="_blank" rel="noopener noreferrer">{{ post.title }}</a>
-            {% else %}
-              <a class="post-title" href="{{ post.redirect | relative_url }}">{{ post.title }}</a>
-            {% endif %}
-          </h3>
-          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
-          <p class="post-meta">{{ post.date | date: '%B %d, %Y' }}</p>
-        </li>
-      {% endfor %}
-    </ul>
-  </section>
+<div class="container featured-posts">
+{% assign is_even = featured_posts.size | modulo: 2 %}
+<div class="row row-cols-{% if featured_posts.size <= 2 or is_even == 0 %}2{% else %}3{% endif %}">
+{% for post in featured_posts %}
+<div class="col mb-4">
+<a href="{{ post.url | relative_url }}">
+<div class="card hoverable">
+<div class="row g-0">
+<div class="col-md-12">
+<div class="card-body">
+<div class="float-right">
+<i class="fa-solid fa-thumbtack fa-xs"></i>
+</div>
+<h3 class="card-title text-lowercase">{{ post.title }}</h3>
+<p class="card-text">{{ post.description }}</p>
 
-  {% assign essay_posts = site.posts | where: "lane", "essay" %}
-  <section id="essays" aria-labelledby="essays-title">
-    <h2 id="essays-title">Essays</h2>
-    <p>Longer-form reflections on ideas, judgment, learning, and the relationship between technical work and a wider life.</p>
-    <ul class="post-list">
-      {% for post in essay_posts %}
-        <li>
-          <h3><a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-          {% if post.description %}<p>{{ post.description }}</p>{% endif %}
-          <p class="post-meta">{{ post.date | date: '%B %d, %Y' }}</p>
-        </li>
-      {% endfor %}
-    </ul>
-  </section>
+                    {% if post.external_source == blank %}
+                      {% assign read_time = post.content | number_of_words | divided_by: 180 | plus: 1 %}
+                    {% else %}
+                      {% assign read_time = post.feed_content | strip_html | number_of_words | divided_by: 180 | plus: 1 %}
+                    {% endif %}
+                    {% assign year = post.date | date: "%Y" %}
 
-  {% assign featured_posts = site.posts | where: "featured", "true" %}
-  {% if featured_posts.size > 0 %}
-    <hr>
-    <h2>Featured</h2>
-    <div class="container featured-posts">
-      {% assign is_even = featured_posts.size | modulo: 2 %}
-      <div class="row row-cols-{% if featured_posts.size <= 2 or is_even == 0 %}2{% else %}3{% endif %}">
-        {% for post in featured_posts %}
-          <div class="col mb-4">
-            <a href="{{ post.url | relative_url }}">
-              <div class="card hoverable">
-                <div class="row g-0">
-                  <div class="col-md-12">
-                    <div class="card-body">
-                      <div class="float-right"><i class="fa-solid fa-thumbtack fa-xs"></i></div>
-                      <h3 class="card-title">{{ post.title }}</h3>
-                      <p class="card-text">{{ post.description }}</p>
-                      {% if post.external_source == blank %}
-                        {% assign read_time = post.content | number_of_words | divided_by: 180 | plus: 1 %}
-                      {% else %}
-                        {% assign read_time = post.feed_content | strip_html | number_of_words | divided_by: 180 | plus: 1 %}
-                      {% endif %}
-                      {% assign year = post.date | date: "%Y" %}
-                      <p class="post-meta">
-                        {{ read_time }} min read &nbsp; &middot; &nbsp;
-                        <a href="{{ year | prepend: '/blog/' | relative_url }}"><i class="fa-solid fa-calendar fa-sm"></i> {{ year }}</a>
-                      </p>
-                    </div>
+                    <p class="post-meta">
+                      {{ read_time }} min read &nbsp; &middot; &nbsp;
+                      <a href="{{ year | prepend: '/blog/' | relative_url }}">
+                        <i class="fa-solid fa-calendar fa-sm"></i> {{ year }} </a>
+                    </p>
                   </div>
                 </div>
               </div>
-            </a>
-          </div>
-        {% endfor %}
+            </div>
+          </a>
+        </div>
+      {% endfor %}
       </div>
     </div>
-  {% endif %}
+    <hr>
 
-  <hr>
-  <h2 id="all-notes">All notes</h2>
+{% endif %}
+
   <ul class="post-list">
+
     {% if page.pagination.enabled %}
       {% assign postlist = paginator.posts %}
     {% else %}
@@ -159,60 +110,87 @@ pagination:
     {% endif %}
 
     {% for post in postlist %}
-      {% if post.external_source == blank %}
-        {% assign read_time = post.content | number_of_words | divided_by: 180 | plus: 1 %}
-      {% else %}
-        {% assign read_time = post.feed_content | strip_html | number_of_words | divided_by: 180 | plus: 1 %}
-      {% endif %}
-      {% assign year = post.date | date: "%Y" %}
-      {% assign tags = post.tags | join: "" %}
-      {% assign categories = post.categories | join: "" %}
 
-      <li>
-        {% if post.thumbnail %}<div class="row"><div class="col-sm-9">{% endif %}
+    {% if post.external_source == blank %}
+      {% assign read_time = post.content | number_of_words | divided_by: 180 | plus: 1 %}
+    {% else %}
+      {% assign read_time = post.feed_content | strip_html | number_of_words | divided_by: 180 | plus: 1 %}
+    {% endif %}
+    {% assign year = post.date | date: "%Y" %}
+    {% assign tags = post.tags | join: "" %}
+    {% assign categories = post.categories | join: "" %}
+
+    <li>
+
+{% if post.thumbnail %}
+
+<div class="row">
+          <div class="col-sm-9">
+{% endif %}
         <h3>
-          {% if post.redirect == blank %}
-            <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          {% elsif post.redirect contains '://' %}
-            <a class="post-title" href="{{ post.redirect }}" target="_blank" rel="noopener noreferrer">{{ post.title }}</a>
-            <svg width="2rem" height="2rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          {% else %}
-            <a class="post-title" href="{{ post.redirect | relative_url }}">{{ post.title }}</a>
-          {% endif %}
-        </h3>
-        <p>{{ post.description }}</p>
-        <p class="post-meta">
-          {{ read_time }} min read &nbsp; &middot; &nbsp;
-          {{ post.date | date: '%B %d, %Y' }}
-          {% if post.external_source %}&nbsp; &middot; &nbsp; {{ post.external_source }}{% endif %}
-        </p>
-        <p class="post-tags">
-          <a href="{{ year | prepend: '/blog/' | relative_url }}"><i class="fa-solid fa-calendar fa-sm"></i> {{ year }}</a>
-          {% if tags != "" %}
-            &nbsp; &middot; &nbsp;
-            {% for tag in post.tags %}
-              <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}"><i class="fa-solid fa-hashtag fa-sm"></i> {{ tag }}</a>{% unless forloop.last %}&nbsp;{% endunless %}
-            {% endfor %}
-          {% endif %}
-          {% if categories != "" %}
-            &nbsp; &middot; &nbsp;
-            {% for category in post.categories %}
-              <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}"><i class="fa-solid fa-tag fa-sm"></i> {{ category }}</a>{% unless forloop.last %}&nbsp;{% endunless %}
-            {% endfor %}
-          {% endif %}
-        </p>
-        {% if post.thumbnail %}
-          </div>
-          <div class="col-sm-3"><img class="card-img" src="{{ post.thumbnail | relative_url }}" style="object-fit: cover; height: 90%" alt=""></div>
-          </div>
+        {% if post.redirect == blank %}
+          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        {% elsif post.redirect contains '://' %}
+          <a class="post-title" href="{{ post.redirect }}" target="_blank">{{ post.title }}</a>
+          <svg width="2rem" height="2rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+            <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
+          </svg>
+        {% else %}
+          <a class="post-title" href="{{ post.redirect | relative_url }}">{{ post.title }}</a>
         {% endif %}
-      </li>
+      </h3>
+      <p>{{ post.description }}</p>
+      <p class="post-meta">
+        {{ read_time }} min read &nbsp; &middot; &nbsp;
+        {{ post.date | date: '%B %d, %Y' }}
+        {% if post.external_source %}
+        &nbsp; &middot; &nbsp; {{ post.external_source }}
+        {% endif %}
+      </p>
+      <p class="post-tags">
+        <a href="{{ year | prepend: '/blog/' | relative_url }}">
+          <i class="fa-solid fa-calendar fa-sm"></i> {{ year }} </a>
+
+          {% if tags != "" %}
+          &nbsp; &middot; &nbsp;
+            {% for tag in post.tags %}
+            <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">
+              <i class="fa-solid fa-hashtag fa-sm"></i> {{ tag }}</a>
+              {% unless forloop.last %}
+                &nbsp;
+              {% endunless %}
+              {% endfor %}
+          {% endif %}
+
+          {% if categories != "" %}
+          &nbsp; &middot; &nbsp;
+            {% for category in post.categories %}
+            <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">
+              <i class="fa-solid fa-tag fa-sm"></i> {{ category }}</a>
+              {% unless forloop.last %}
+                &nbsp;
+              {% endunless %}
+              {% endfor %}
+          {% endif %}
+    </p>
+
+{% if post.thumbnail %}
+
+</div>
+
+  <div class="col-sm-3">
+    <img class="card-img" src="{{ post.thumbnail | relative_url }}" style="object-fit: cover; height: 90%" alt="image">
+  </div>
+</div>
+{% endif %}
+    </li>
+
     {% endfor %}
+
   </ul>
 
-  {% if page.pagination.enabled %}
-    {% include pagination.liquid %}
-  {% endif %}
+{% if page.pagination.enabled %}
+{% include pagination.liquid %}
+{% endif %}
+
 </div>

--- a/_posts/2021-03-31-90s.md
+++ b/_posts/2021-03-31-90s.md
@@ -3,7 +3,6 @@ layout: post
 title: Intergenerational justice of climate change
 description: and the mission of 90s
 date: 2021-03-31
-lane: essay
 tags:
   - 人与自然
   - lifebook

--- a/_posts/2022-05-04-ice-block-expedition.md
+++ b/_posts/2022-05-04-ice-block-expedition.md
@@ -4,7 +4,6 @@ title: The Ice Block Expedition 1957
 author: Zhihao
 description: What if the ice block expedition 1959 happens in 2021?
 date: 2022-05-04
-lane: field
 tags: links
 categories: modeling links
 redirect: /assets/pdf/iceblock_expedition.pptx

--- a/_posts/2025-11-01-crst-publication.md
+++ b/_posts/2025-11-01-crst-publication.md
@@ -4,7 +4,6 @@ title: "Latest Publication: Snow Depth Downscaling in CRST"
 author: Zhihao
 description: "Retrieving snow depth distribution by downscaling ERA5 Reanalysis with ICESat-2 laser altimetry."
 date: 2025-11-01
-lane: research
 tags: links research
 categories: climate remote_sensing links
 redirect: https://www.sciencedirect.com/science/article/pii/S0165232X25001636

--- a/_posts/2026-03-08-lifeos-5-agentic-brain.md
+++ b/_posts/2026-03-08-lifeos-5-agentic-brain.md
@@ -2,7 +2,6 @@
 layout: post
 title: 'The Agentic Brain: A Blueprint for Personal AI OS with LifeOS 5.0'
 date: 2026-03-08
-lane: build
 categories: [AI, LifeOS, Architecture]
 thumbnail: assets/img/lifeos-5-logo.svg
 img: assets/img/lifeos-5-logo.svg

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -49,16 +49,15 @@ A `Latest notes` block exists behind `_config.yml` → `home_latest_notes.enable
 
 ### Blog
 
-Blog is the editorial reading surface. Its reader-facing lanes are:
+Blog keeps the native al-folio chronological reading flow as its visual and structural baseline.
 
-- **Research Notes** — methods, datasets, papers, and technical reasoning;
-- **Build Logs** — architecture decisions, agentic workflows, and shipped systems;
-- **Field Notes** — field work, expeditions, travel, and direct operational observations;
-- **Essays** — longer-form reflections on ideas, judgment, learning, and life beyond technical work.
+- The main surface remains one paginated post stream.
+- Existing `tags` and `categories` are the only editorial taxonomy mechanism.
+- `display_tags` and `display_categories` may be curated to improve discovery without changing the post-list layout.
+- Featured posts may remain above the chronological stream using the theme's existing card treatment.
+- Do not introduce a second classification field such as `lane`, parallel sectioned feeds, or a custom Blog-only layout system.
 
-The four lanes are editorial entry points. The chronological `All notes` archive remains complete beneath them.
-
-Historical tags and categories remain useful archive metadata, but they do not define the top-level Blog information architecture.
+Information-architecture improvements should therefore be incremental: improve names, descriptions, and the existing taxonomy first; do not restructure the page when a metadata or copy change is sufficient.
 
 ### Projects and repositories
 

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -100,13 +100,7 @@ requireIncludes(
 );
 requireAbsent(
   visualPlugin,
-  [
-    "site-polish.css",
-    "site-upgrade.css",
-    "hao-design.css",
-    "hao-home-safe.css",
-    "apply_home_portfolio_link",
-  ],
+  ["site-polish.css", "site-upgrade.css", "hao-design.css", "hao-home-safe.css", "apply_home_portfolio_link"],
   "Site visual polish plugin",
 );
 
@@ -141,34 +135,40 @@ const blogPage = read("_pages/blog.md");
 requireIncludes(
   blogPage,
   [
-    "Research notes on climate, geospatial data, AI systems, and things I build.",
-    "Mens sana in corpore sano.",
+    '<div class="post">',
+    "site.blog_name",
+    "site.blog_description",
+    "site.display_tags",
+    "site.display_categories",
+    '{% assign featured_posts = site.posts | where: "featured", "true" %}',
+    "{% assign postlist = paginator.posts %}",
+    'class="post-title"',
+    "{% include pagination.liquid %}",
+  ],
+  "Blog index",
+);
+requireAbsent(
+  blogPage,
+  [
+    "hao-blog-index",
+    "Editorial lanes",
+    'site.posts | where: "lane"',
     'id="research-notes"',
     'id="build-logs"',
     'id="field-notes"',
     'id="essays"',
-    'site.posts | where: "lane", "research"',
-    'site.posts | where: "lane", "build"',
-    'site.posts | where: "lane", "field"',
-    'site.posts | where: "lane", "essay"',
-    "Research Notes",
-    "Build Logs",
-    "Field Notes",
-    "Essays",
     'id="all-notes"',
   ],
   "Blog index",
 );
-requireAbsent(blogPage, ["text-lowercase", "post.url contains '/"], "Blog index");
 
-const lanePosts = {
-  "_posts/2025-11-01-crst-publication.md": "research",
-  "_posts/2026-03-08-lifeos-5-agentic-brain.md": "build",
-  "_posts/2022-05-04-ice-block-expedition.md": "field",
-  "_posts/2021-03-31-90s.md": "essay",
-};
-for (const [postPath, lane] of Object.entries(lanePosts)) {
-  requireRegex(read(postPath), new RegExp(`^lane:\\s*${lane}\\s*$`, "m"), `${postPath} must declare lane: ${lane}.`);
+for (const postPath of [
+  "_posts/2025-11-01-crst-publication.md",
+  "_posts/2026-03-08-lifeos-5-agentic-brain.md",
+  "_posts/2022-05-04-ice-block-expedition.md",
+  "_posts/2021-03-31-90s.md",
+]) {
+  requireAbsent(read(postPath), ["lane:"], `${postPath} front matter`);
 }
 
 const currentOperations = read("_data/current_operations.yml");
@@ -210,10 +210,9 @@ requireIncludes(
   [
     "Research & Product Studio",
     "The current production site is the source of truth.",
-    "Research Notes",
-    "Build Logs",
-    "Field Notes",
-    "Essays",
+    "Blog keeps the native al-folio chronological reading flow",
+    "Existing `tags` and `categories` are the only editorial taxonomy mechanism.",
+    "Do not introduce a second classification field such as `lane`",
     "Post-render HTML regex rewriting is technical debt.",
     "Feature switches should use existing Jekyll/al-folio configuration directly.",
   ],


### PR DESCRIPTION
## Why

The Blog IA change in #109 altered the native al-folio reading rhythm too aggressively. The four sectioned `lane` feeds made the page visually awkward and introduced a second taxonomy system that the site did not need.

## What changed

- Restore `_pages/blog.md` to the pre-#109 native al-folio structure: header, existing tag/category navigation, featured posts, one chronological paginated post stream.
- Remove the four `lane:` front-matter additions introduced by #109.
- Keep the existing `tags` / `categories` mechanism as the only Blog taxonomy layer.
- Update the design contract to require incremental IA changes on top of the native Blog layout instead of custom sectioned feeds.
- Update source contracts to reject future `lane`-based Blog architecture.

## Explicitly unchanged

- Native al-folio Search remains enabled.
- Homepage `Latest notes` remains implemented but disabled by default.
- Current Work remains unchanged.
- CSS cleanup and the Portfolio DOM-patch cleanup from #109 remain intact.

This is intentionally a minimal rollback of the Blog-specific architectural change, not a rollback of #109 as a whole.