### PR TITLE
Show search icon without shortcut label

### DIFF
--- a/assets/css/footer-build.css
+++ b/assets/css/footer-build.css
@@ -1,5 +1,14 @@
 /* Compact deployment identifier and legal links appended to the inherited al-folio footer. */
 
+/* Keep native search behavior and shortcut support, but show only the search icon in the navbar. */
+#search-toggle .nav-link {
+  font-size: 0;
+}
+
+#search-toggle .nav-link .fa-magnifying-glass {
+  font-size: 1rem;
+}
+
 .hao-legal-links {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What changed

- Keep the native al-folio search button and search behavior unchanged.
- Hide the visible `ctrl k` / `⌘ k` shortcut label in the navbar.
- Keep only the magnifying-glass icon visible.
- Keep keyboard shortcut support, `title="Search"`, and `aria-label="Open search"` intact.

## Implementation

This is intentionally a two-rule CSS override in the already-loaded global stylesheet. No local header copy, no new stylesheet, no DOM regex patch, and no search-plugin fork.