### PR TITLE
Revert search icon-only navbar styling

### DIFF
--- a/assets/css/footer-build.css
+++ b/assets/css/footer-build.css
@@ -1,14 +1,5 @@
 /* Compact deployment identifier and legal links appended to the inherited al-folio footer. */
 
-/* Keep native search behavior and shortcut support, but show only the search icon in the navbar. */
-#search-toggle .nav-link {
-  font-size: 0;
-}
-
-#search-toggle .nav-link .fa-magnifying-glass {
-  font-size: 1rem;
-}
-
 .hao-legal-links {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Revert PR #111 exactly. Restore `assets/css/footer-build.css` to its pre-#111 content so the navbar search returns to the native al-folio presentation. No other search, Blog, homepage, or visual changes are included.