### PR TITLE
Use categories for Blog information architecture

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -105,6 +105,7 @@ pagination:
     {% endif %}
     {% assign year = post.date | date: "%Y" %}
     {% assign tags = post.tags | join: "" %}
+    {% assign categories = post.categories | join: "" %}
 
     <li>
 
@@ -142,6 +143,17 @@ pagination:
             {% for tag in post.tags %}
             <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">
               <i class="fa-solid fa-hashtag fa-sm"></i> {{ tag }}</a>
+              {% unless forloop.last %}
+                &nbsp;
+              {% endunless %}
+              {% endfor %}
+          {% endif %}
+
+          {% if categories != "" %}
+          &nbsp; &middot; &nbsp;
+            {% for category in post.categories %}
+            <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">
+              <i class="fa-solid fa-tag fa-sm"></i> {{ category }}</a>
               {% unless forloop.last %}
                 &nbsp;
               {% endunless %}

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -29,32 +29,19 @@ pagination:
   </div>
   {% endif %}
 
-{% if site.display_tags and site.display_tags.size > 0 or site.display_categories and site.display_categories.size > 0 %}
-
-  <div class="tag-category-list">
-    <ul class="p-0 m-0">
-      {% for tag in site.display_tags %}
-        <li>
-          <i class="fa-solid fa-hashtag fa-sm"></i> <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">{{ tag }}</a>
-        </li>
-        {% unless forloop.last %}
-          <p>&bull;</p>
-        {% endunless %}
-      {% endfor %}
-      {% if site.display_categories.size > 0 and site.display_tags.size > 0 %}
+{% assign primary_categories = "Research Notes|Build Logs|Field Notes|Essays" | split: "|" %}
+<div class="tag-category-list">
+  <ul class="p-0 m-0">
+    {% for category in primary_categories %}
+      <li>
+        <i class="fa-solid fa-tag fa-sm"></i> <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">{{ category }}</a>
+      </li>
+      {% unless forloop.last %}
         <p>&bull;</p>
-      {% endif %}
-      {% for category in site.display_categories %}
-        <li>
-          <i class="fa-solid fa-tag fa-sm"></i> <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">{{ category }}</a>
-        </li>
-        {% unless forloop.last %}
-          <p>&bull;</p>
-        {% endunless %}
-      {% endfor %}
-    </ul>
-  </div>
-  {% endif %}
+      {% endunless %}
+    {% endfor %}
+  </ul>
+</div>
 
 {% assign featured_posts = site.posts | where: "featured", "true" %}
 {% if featured_posts.size > 0 %}
@@ -118,7 +105,6 @@ pagination:
     {% endif %}
     {% assign year = post.date | date: "%Y" %}
     {% assign tags = post.tags | join: "" %}
-    {% assign categories = post.categories | join: "" %}
 
     <li>
 
@@ -156,17 +142,6 @@ pagination:
             {% for tag in post.tags %}
             <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">
               <i class="fa-solid fa-hashtag fa-sm"></i> {{ tag }}</a>
-              {% unless forloop.last %}
-                &nbsp;
-              {% endunless %}
-              {% endfor %}
-          {% endif %}
-
-          {% if categories != "" %}
-          &nbsp; &middot; &nbsp;
-            {% for category in post.categories %}
-            <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">
-              <i class="fa-solid fa-tag fa-sm"></i> {{ category }}</a>
               {% unless forloop.last %}
                 &nbsp;
               {% endunless %}

--- a/_posts/2021-03-31-90s.md
+++ b/_posts/2021-03-31-90s.md
@@ -7,8 +7,9 @@ tags:
   - 人与自然
   - lifebook
   - climate
-categories:
   - note
+categories:
+  - Essays
 publish: true
 author: Zhihao
 lang: eng

--- a/_posts/2022-05-04-ice-block-expedition.md
+++ b/_posts/2022-05-04-ice-block-expedition.md
@@ -4,8 +4,8 @@ title: The Ice Block Expedition 1957
 author: Zhihao
 description: What if the ice block expedition 1959 happens in 2021?
 date: 2022-05-04
-tags: links
-categories: modeling links
+tags: [links, modeling]
+categories: ["Field Notes"]
 redirect: /assets/pdf/iceblock_expedition.pptx
 lang: eng
 publish: true

--- a/_posts/2025-11-01-crst-publication.md
+++ b/_posts/2025-11-01-crst-publication.md
@@ -4,8 +4,8 @@ title: "Latest Publication: Snow Depth Downscaling in CRST"
 author: Zhihao
 description: "Retrieving snow depth distribution by downscaling ERA5 Reanalysis with ICESat-2 laser altimetry."
 date: 2025-11-01
-tags: links research
-categories: climate remote_sensing links
+tags: [links, research, climate, remote_sensing]
+categories: ["Research Notes"]
 redirect: https://www.sciencedirect.com/science/article/pii/S0165232X25001636
 lang: eng
 publish: true

--- a/_posts/2026-03-08-lifeos-5-agentic-brain.md
+++ b/_posts/2026-03-08-lifeos-5-agentic-brain.md
@@ -2,7 +2,8 @@
 layout: post
 title: 'The Agentic Brain: A Blueprint for Personal AI OS with LifeOS 5.0'
 date: 2026-03-08
-categories: [AI, LifeOS, Architecture]
+tags: [AI, LifeOS, Architecture]
+categories: ["Build Logs"]
 thumbnail: assets/img/lifeos-5-logo.svg
 img: assets/img/lifeos-5-logo.svg
 og_image: assets/img/lifeos-5-logo.svg

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -53,11 +53,12 @@ Blog keeps the native al-folio chronological reading flow as its visual and stru
 
 - The main surface remains one paginated post stream.
 - Existing `tags` and `categories` are the only editorial taxonomy mechanism.
-- `display_tags` and `display_categories` may be curated to improve discovery without changing the post-list layout.
+- `categories` define the top-level Blog information architecture and are shown at the top of the Blog: **Research Notes**, **Build Logs**, **Field Notes**, and **Essays**.
+- `tags` remain fine-grained descriptors for subject matter, technologies, methods, places, and other cross-cutting themes.
 - Featured posts may remain above the chronological stream using the theme's existing card treatment.
 - Do not introduce a second classification field such as `lane`, parallel sectioned feeds, or a custom Blog-only layout system.
 
-Information-architecture improvements should therefore be incremental: improve names, descriptions, and the existing taxonomy first; do not restructure the page when a metadata or copy change is sufficient.
+Information-architecture improvements should therefore be incremental: keep the four category entry points stable, improve tags and post metadata in place, and preserve the chronological stream as the reading backbone.
 
 ### Projects and repositories
 

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -138,8 +138,11 @@ requireIncludes(
     '<div class="post">',
     "site.blog_name",
     "site.blog_description",
-    "site.display_tags",
-    "site.display_categories",
+    "primary_categories",
+    "Research Notes|Build Logs|Field Notes|Essays",
+    "'/blog/category/'",
+    "post.tags",
+    "'/blog/tag/'",
     '{% assign featured_posts = site.posts | where: "featured", "true" %}',
     "{% assign postlist = paginator.posts %}",
     'class="post-title"',
@@ -162,13 +165,16 @@ requireAbsent(
   "Blog index",
 );
 
-for (const postPath of [
-  "_posts/2025-11-01-crst-publication.md",
-  "_posts/2026-03-08-lifeos-5-agentic-brain.md",
-  "_posts/2022-05-04-ice-block-expedition.md",
-  "_posts/2021-03-31-90s.md",
-]) {
-  requireAbsent(read(postPath), ["lane:"], `${postPath} front matter`);
+const representativeCategories = new Map([
+  ["_posts/2025-11-01-crst-publication.md", "Research Notes"],
+  ["_posts/2026-03-08-lifeos-5-agentic-brain.md", "Build Logs"],
+  ["_posts/2022-05-04-ice-block-expedition.md", "Field Notes"],
+  ["_posts/2021-03-31-90s.md", "Essays"],
+]);
+for (const [postPath, category] of representativeCategories) {
+  const post = read(postPath);
+  requireAbsent(post, ["lane:"], `${postPath} front matter`);
+  requireIncludes(post, [category, "tags:"], `${postPath} taxonomy`);
 }
 
 const currentOperations = read("_data/current_operations.yml");
@@ -212,6 +218,9 @@ requireIncludes(
     "The current production site is the source of truth.",
     "Blog keeps the native al-folio chronological reading flow",
     "Existing `tags` and `categories` are the only editorial taxonomy mechanism.",
+    "`categories` define the top-level Blog information architecture",
+    "**Research Notes**, **Build Logs**, **Field Notes**, and **Essays**",
+    "`tags` remain fine-grained descriptors",
     "Do not introduce a second classification field such as `lane`",
     "Post-render HTML regex rewriting is technical debt.",
     "Feature switches should use existing Jekyll/al-folio configuration directly.",


### PR DESCRIPTION
## What changed

- Keep the native al-folio Blog header, featured posts, chronological paginated stream, and per-post taxonomy display.
- Show four primary category entry points at the top: **Research Notes**, **Build Logs**, **Field Notes**, and **Essays**.
- Keep detailed subject/technology metadata as normal `tags`.
- Seed each primary category with an existing representative post, moving its former topic-like category values into tags where appropriate.
- Update the design-system and source contract to lock this hierarchy.

## Architecture

This uses only existing Jekyll/al-folio `categories` and `tags`. It does **not** add `lane`, a second taxonomy field, parallel category feeds, new CSS, or a Blog-specific layout system. The chronological stream remains the reading backbone.