### PR TITLE
Backfill canonical Blog categories across all posts

### DIFF
--- a/_posts/2020-05-22-fujin.md
+++ b/_posts/2020-05-22-fujin.md
@@ -10,6 +10,8 @@ tags:
   - 人文
   - 人与自我
   - lifebook
+categories:
+  - Essays
 status: done
 filename: 2020-05-22-fujin
 ---

--- a/_posts/2020-06-07-xb1.md
+++ b/_posts/2020-06-07-xb1.md
@@ -8,6 +8,8 @@ publish: true
 tags:
   - 学思笔记
   - 人文
+categories:
+  - Essays
 filename: 2020-06-07-xb1
 ---
 

--- a/_posts/2020-06-08-xb2.md
+++ b/_posts/2020-06-08-xb2.md
@@ -9,6 +9,8 @@ tags:
   - 学思笔记
   - 人文
   - blog
+categories:
+  - Essays
 filename: 2020-06-08-xb2
 ---
 

--- a/_posts/2020-06-09-xb3.md
+++ b/_posts/2020-06-09-xb3.md
@@ -8,6 +8,8 @@ publish: true
 tags:
   - 学思笔记
   - 人文
+categories:
+  - Essays
 filename: 2020-06-09-xb3
 ---
 

--- a/_posts/2020-06-22-renming.md
+++ b/_posts/2020-06-22-renming.md
@@ -8,6 +8,8 @@ publish: true
 tags:
   - 学思笔记
   - 人文
+categories:
+  - Essays
 filename: 2020-06-22-renming
 ---
 

--- a/_posts/2020-09-01-fangfa.md
+++ b/_posts/2020-09-01-fangfa.md
@@ -7,6 +7,8 @@ author: Zhihao
 tags:
   - 学思笔记
   - 人文
+categories:
+  - Essays
 publish: true
 filename: 2020-09-01-fangfa
 ---

--- a/_posts/2021-03-31-90s.md
+++ b/_posts/2021-03-31-90s.md
@@ -7,7 +7,6 @@ tags:
   - 人与自然
   - lifebook
   - climate
-  - note
 categories:
   - Essays
 publish: true

--- a/_posts/2021-11-04-Argriculture_change_detection.md
+++ b/_posts/2021-11-04-Argriculture_change_detection.md
@@ -4,8 +4,10 @@ title: Agriculture Change Detection
 author: Zhihao
 description: a Case Study of the Nile Delta in Egypt
 date: 2021-11-04
-tags: links
-categories: remote_sensing links
+tags:
+  - remote_sensing
+categories:
+  - Research Notes
 redirect: /assets/pdf/Change_detection_on_argriculture.pdf
 lang: eng
 publish: true

--- a/_posts/2022-03-31-gnss.md
+++ b/_posts/2022-03-31-gnss.md
@@ -5,7 +5,8 @@ description: The best tools for finding a answer
 date: 2022-03-31
 tags:
   - gnss
-categories: notes
+categories:
+  - Research Notes
 publish: true
 filename: 2022-03-31-gnss
 ---

--- a/_posts/2022-04-13-ski-trip-2022.md
+++ b/_posts/2022-04-13-ski-trip-2022.md
@@ -5,7 +5,7 @@ author: Zhihao
 description: What's the next?
 date: 2022-04-13
 categories:
-  - images
+  - Field Notes
 tags:
   - withme
   - norge

--- a/_posts/2022-05-04-ice-block-expedition.md
+++ b/_posts/2022-05-04-ice-block-expedition.md
@@ -4,8 +4,10 @@ title: The Ice Block Expedition 1957
 author: Zhihao
 description: What if the ice block expedition 1959 happens in 2021?
 date: 2022-05-04
-tags: [links, modeling]
-categories: ["Field Notes"]
+tags:
+  - modeling
+categories:
+  - Field Notes
 redirect: /assets/pdf/iceblock_expedition.pptx
 lang: eng
 publish: true

--- a/_posts/2022-08-26-obsidian-001.md
+++ b/_posts/2022-08-26-obsidian-001.md
@@ -8,7 +8,7 @@ tags:
   - Obsidian
   - PKM
 categories:
-  - notes
+  - Build Logs
 lang: eng
 publish: true
 filename: 2022-08-26-obsidian-001
@@ -64,7 +64,7 @@ The natural steps of emerging of ideas are capturing, processing and doing. Thus
 
 In obsidian, we have the [Checklist plugin](https://github.com/delashum/obsidian-checklist-plugin) to implement the GTD system. What I do is tagging all tasks with `todo/ing`, `todo/next`, `todo/someday`, `todo/inbox`. And [Tasks plugin](https://github.com/obsidian-tasks-group/obsidian-tasks) help you mark and organize them.
 
-![Pasted image 20220827165203.png](https://assets.asana.biz/m/6f89f3691b3dffaa/original/inline-leadership-eisenhower-matrix-4-2x.jpg)
+![Pasted image 20220827165203.png](https://assets.asana.biz/m/6f89f369b3dffaa/original/inline-leadership-eisenhower-matrix-4-2x.jpg)
 
 ### 1.3 Kanban Project Management
 

--- a/_posts/2022-09-16-glacier-buzzsaw.md
+++ b/_posts/2022-09-16-glacier-buzzsaw.md
@@ -9,7 +9,7 @@ tags:
   - glacier
   - geomorphology
 categories:
-  - notes
+  - Research Notes
 filename: 2022-09-16-glacier-buzzsaw
 ---
 

--- a/_posts/2022-10-13-landscape-m.md
+++ b/_posts/2022-10-13-landscape-m.md
@@ -5,7 +5,7 @@ author: Zhihao
 description: large scale of geomorphology - erosion vs tectonic uplift
 date: 2022-10-13
 categories:
-  - notes
+  - Research Notes
 tags:
   - geomorphology
 bibliography: lib.bib

--- a/_posts/2022-10-13-permafrost-m.md
+++ b/_posts/2022-10-13-permafrost-m.md
@@ -5,7 +5,7 @@ author: Zhihao
 description: Thawing permafrost is the function of the global warming
 date: 2022-10-13
 categories:
-  - notes
+  - Research Notes
 tags:
   - permafrost
   - climate

--- a/_posts/2022-11-20-Quaternary-geomorphology-of-Norway.md
+++ b/_posts/2022-11-20-Quaternary-geomorphology-of-Norway.md
@@ -3,11 +3,12 @@ layout: distill
 title: Field Trip to Ice Age Museum
 description: The most interesting Quaternary geomorphology story of Norway
 tags:
-  - notes
   - geomorphology
   - glacier
   - climate
   - permafrost
+categories:
+  - Field Notes
 giscus_comments: false
 date: 2022-11-20
 featured: true

--- a/_posts/2022-12-25-full-stack.md
+++ b/_posts/2022-12-25-full-stack.md
@@ -4,7 +4,8 @@ title: Becoming a Full-Stack Geodata Scientist
 author: ChatGPT
 description: a talk with ChatGPT about career planning
 date: 2022-12-25
-categories: notes
+categories:
+  - Essays
 tags:
   - geodata
   - datascience

--- a/_posts/2022-12-26-xc.md
+++ b/_posts/2022-12-26-xc.md
@@ -8,7 +8,7 @@ tags:
   - skiing
   - sports
 categories:
-  - notes
+  - Field Notes
 lang: eng
 publish: true
 filename: 2022-12-26-xc

--- a/_posts/2023-01-01-tea.md
+++ b/_posts/2023-01-01-tea.md
@@ -8,7 +8,7 @@ tags:
   - life
   - tea
 categories:
-  - notes
+  - Essays
 lang: eng
 publish: true
 status: done

--- a/_posts/2023-01-02-dem-coreg.md
+++ b/_posts/2023-01-02-dem-coreg.md
@@ -4,7 +4,8 @@ title: DEM Coreg is a bound-restricted minimizing problem
 author: Zhihao
 description: but suffering from noise
 date: 2023-01-02
-categories: notes
+categories:
+  - Research Notes
 tags:
   - geodata
   - datascience

--- a/_posts/2023-01-02-gdc.md
+++ b/_posts/2023-01-02-gdc.md
@@ -4,7 +4,8 @@ title: NuthKaab Coreg vs Gradient Descent Coreg
 author: Zhihao
 description: I just created the best ever coreg tool?
 date: 2023-01-02
-categories: notes
+categories:
+  - Build Logs
 tags:
   - geodata
   - datascience

--- a/_posts/2023-02-08-SDG2023.md
+++ b/_posts/2023-02-08-SDG2023.md
@@ -4,8 +4,11 @@ title: My talk at SDG 2023
 author: Zhihao
 description: The scerets behind the snow depth
 date: 2023-02-07
-tags: links
-categories: sustainable climate links
+tags:
+  - sustainable
+  - climate
+categories:
+  - Research Notes
 redirect: /assets/pdf/SDG2023_zhihao_snowdepth.pdf
 lang: eng
 publish: true

--- a/_posts/2023-03-26-LATICE2023.md
+++ b/_posts/2023-03-26-LATICE2023.md
@@ -4,8 +4,11 @@ title: My Poster at LATICE 2023
 author: Zhihao
 description: Snow Depth from Satellite Laser Altimetry - Co-registration, Bias Correction, and Statistical Downscaling
 date: 2023-03-26
-tags: links
-categories: climate datascience links
+tags:
+  - climate
+  - datascience
+categories:
+  - Research Notes
 redirect: /assets/pdf/LATICE2023_zhihao_poster_snowdepth.pdf
 lang: eng
 publish: true

--- a/_posts/2023-05-12-abstract.md
+++ b/_posts/2023-05-12-abstract.md
@@ -4,8 +4,13 @@ title: My thesis in a page
 author: Zhihao
 description: Advancements in Snow Depth Retrieval Using Satellite Altimetry and Machine Learning
 date: 2023-05-12
-tags: links
-categories: climate geomatics remote_sensing machine_learning links
+tags:
+  - climate
+  - geomatics
+  - remote_sensing
+  - machine_learning
+categories:
+  - Research Notes
 redirect: /assets/pdf/Abstract_master_thesis.pdf
 lang: eng
 publish: true

--- a/_posts/2023-11-01-dataset.md
+++ b/_posts/2023-11-01-dataset.md
@@ -4,7 +4,8 @@ title: ICESat-2 vs DTM1, DTM10, Copernicus30, FABDEM
 author: Zhihao
 description: Dataset is available on Zenodo
 date: 2023-11-01
-categories: notes
+categories:
+  - Research Notes
 tags:
   - DEM
   - Snow

--- a/_posts/2023-11-03-subgrid.md
+++ b/_posts/2023-11-03-subgrid.md
@@ -4,7 +4,8 @@ title: A tabular dataset ready for machine learning applications
 author: Zhihao
 description: Retrieved snow depth in Mainland Norway (2018.10-2022.10) based on ICESat-2 ATL 08 and DEMs
 date: 2023-11-03
-categories: notes
+categories:
+  - Research Notes
 tags:
   - DEM
   - Snow

--- a/_posts/2024-01-08-yangming.md
+++ b/_posts/2024-01-08-yangming.md
@@ -8,7 +8,8 @@ tags:
   - 人文
   - 人与自我
   - lifebook
-categories: notes
+categories:
+  - Essays
 lang: eng
 publish: true
 comments: false

--- a/_posts/2025-11-01-crst-publication.md
+++ b/_posts/2025-11-01-crst-publication.md
@@ -4,8 +4,12 @@ title: "Latest Publication: Snow Depth Downscaling in CRST"
 author: Zhihao
 description: "Retrieving snow depth distribution by downscaling ERA5 Reanalysis with ICESat-2 laser altimetry."
 date: 2025-11-01
-tags: [links, research, climate, remote_sensing]
-categories: ["Research Notes"]
+tags:
+  - research
+  - climate
+  - remote_sensing
+categories:
+  - Research Notes
 redirect: https://www.sciencedirect.com/science/article/pii/S0165232X25001636
 lang: eng
 publish: true

--- a/_posts/2026-03-05-obsidian-graph-rag.md
+++ b/_posts/2026-03-05-obsidian-graph-rag.md
@@ -2,7 +2,12 @@
 layout: post
 title: "让 AI 看见你的大脑：Obsidian CLI 的价值与意义"
 date: 2026-03-05
-categories: [AI, Obsidian, LifeOS]
+tags:
+  - AI
+  - Obsidian
+  - LifeOS
+categories:
+  - Build Logs
 ---
 
 当我们谈论“第二大脑”时，大多数人的直觉依然停留在“容器”的概念上：一个存放笔记、文档和碎片的数字仓库。然而，Obsidian 的本质从未仅仅是文件夹的堆砌，它的生命力源于点（Node）与线（Edge）的交织。

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -54,7 +54,9 @@ Blog keeps the native al-folio chronological reading flow as its visual and stru
 - The main surface remains one paginated post stream.
 - Existing `tags` and `categories` are the only editorial taxonomy mechanism.
 - `categories` define the top-level Blog information architecture and are shown at the top of the Blog: **Research Notes**, **Build Logs**, **Field Notes**, and **Essays**.
+- Every post has exactly one primary category from those four values.
 - `tags` remain fine-grained descriptors for subject matter, technologies, methods, places, and other cross-cutting themes.
+- Legacy topical categories belong in `tags`; obsolete structural labels such as `notes`, `images`, `links`, and `code` are removed rather than carried forward.
 - Featured posts may remain above the chronological stream using the theme's existing card treatment.
 - Do not introduce a second classification field such as `lane`, parallel sectioned feeds, or a custom Blog-only layout system.
 

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -28,7 +28,7 @@ const frontMatterOf = (source) => {
 };
 
 const categoriesFromFrontMatter = (frontMatter) => {
-  const match = frontMatter.match(/^categories:\s*(.*)$/m);
+  const match = frontMatter.match(/^categories:[ \t]*(.*)$/m);
   if (!match) return [];
 
   const inline = match[1].trim();

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -22,6 +22,34 @@ const requireRegex = (source, regex, message) => {
   if (!regex.test(source)) failures.push(message);
 };
 
+const frontMatterOf = (source) => {
+  const match = source.match(/^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/);
+  return match ? match[1] : "";
+};
+
+const categoriesFromFrontMatter = (frontMatter) => {
+  const match = frontMatter.match(/^categories:\s*(.*)$/m);
+  if (!match) return [];
+
+  const inline = match[1].trim();
+  if (inline) {
+    const value = inline.replace(/^\[/, "").replace(/\]$/, "");
+    return value
+      .split(",")
+      .map((category) => category.trim().replace(/^['"]|['"]$/g, ""))
+      .filter(Boolean);
+  }
+
+  const afterCategories = frontMatter.slice(match.index + match[0].length).split("\n");
+  const categories = [];
+  for (const line of afterCategories) {
+    if (/^\S/.test(line)) break;
+    const item = line.match(/^\s*-\s*(.+?)\s*$/);
+    if (item) categories.push(item[1].trim().replace(/^['"]|['"]$/g, ""));
+  }
+  return categories;
+};
+
 const config = read("_config.yml");
 requireRegex(config, /^\s*theme:\s*al_folio_core\s*$/m, "`_config.yml` must keep `theme: al_folio_core`.");
 for (const pluginName of ["al_folio_core", "al_folio_distill", "al_cookie", "al_icons", "al_math", "al_search"]) {
@@ -165,16 +193,27 @@ requireAbsent(
   "Blog index",
 );
 
-const representativeCategories = new Map([
-  ["_posts/2025-11-01-crst-publication.md", "Research Notes"],
-  ["_posts/2026-03-08-lifeos-5-agentic-brain.md", "Build Logs"],
-  ["_posts/2022-05-04-ice-block-expedition.md", "Field Notes"],
-  ["_posts/2021-03-31-90s.md", "Essays"],
-]);
-for (const [postPath, category] of representativeCategories) {
-  const post = read(postPath);
-  requireAbsent(post, ["lane:"], `${postPath} front matter`);
-  requireIncludes(post, [category, "tags:"], `${postPath} taxonomy`);
+const allowedBlogCategories = new Set(["Research Notes", "Build Logs", "Field Notes", "Essays"]);
+const postFiles = fs.readdirSync(path.join(root, "_posts")).filter((file) => file.endsWith(".md"));
+for (const postFile of postFiles) {
+  const postPath = path.join("_posts", postFile);
+  const frontMatter = frontMatterOf(read(postPath));
+  if (!frontMatter) {
+    failures.push(`${postPath} must have YAML front matter.`);
+    continue;
+  }
+
+  if (/^lane:\s*/m.test(frontMatter)) failures.push(`${postPath} must not use the obsolete \`lane\` taxonomy.`);
+
+  const categories = categoriesFromFrontMatter(frontMatter);
+  if (categories.length !== 1) {
+    failures.push(`${postPath} must have exactly one primary Blog category; found ${categories.length}.`);
+    continue;
+  }
+
+  if (!allowedBlogCategories.has(categories[0])) {
+    failures.push(`${postPath} uses unsupported Blog category \`${categories[0]}\`.`);
+  }
 }
 
 const currentOperations = read("_data/current_operations.yml");
@@ -219,8 +258,10 @@ requireIncludes(
     "Blog keeps the native al-folio chronological reading flow",
     "Existing `tags` and `categories` are the only editorial taxonomy mechanism.",
     "`categories` define the top-level Blog information architecture",
+    "Every post has exactly one primary category",
     "**Research Notes**, **Build Logs**, **Field Notes**, and **Essays**",
     "`tags` remain fine-grained descriptors",
+    "Legacy topical categories belong in `tags`",
     "Do not introduce a second classification field such as `lane`",
     "Post-render HTML regex rewriting is technical debt.",
     "Feature switches should use existing Jekyll/al-folio configuration directly.",


### PR DESCRIPTION
## What changed

- Backfill the entire `_posts` collection so every post has exactly one primary Blog category: **Research Notes**, **Build Logs**, **Field Notes**, or **Essays**.
- Move meaningful legacy topical categories into normal `tags` where needed.
- Delete obsolete structural labels such as `notes`, `images`, `links`, and `code` instead of carrying them forward as tags.
- Preserve existing fine-grained tags and post body content.
- Add a source contract that scans every Markdown post and fails CI unless it has exactly one allowed category; `lane` remains prohibited.
- Document the canonical taxonomy in the design system.

## Architecture

No new taxonomy field, layout, CSS, migration layer, fallback, or dependency. Native Jekyll/al-folio `categories` and `tags` remain the only Blog taxonomy. The chronological Blog stream is unchanged.